### PR TITLE
ABLESTACK copyright 및 version 정보

### DIFF
--- a/ui/public/config.json
+++ b/ui/public/config.json
@@ -2,7 +2,7 @@
   "apiBase": "/client/api",
   "docBase": "http://docs.cloudstack.apache.org/en/latest",
   "appTitle": "ABLESTACK",
-  "footer": "Licensed under the <a href='http://www.apache.org/licenses/' target='_blank'>Apache License</a>, Version 2.0.",
+  "footer": "Copyright (c) 2021, ABLECLOUD.Co.Ltd",
   "logo": "assets/ablestack-logo.png",
   "banner": "assets/ablestack-logo.png",
   "error": {

--- a/ui/src/components/page/GlobalFooter.vue
+++ b/ui/src/components/page/GlobalFooter.vue
@@ -21,12 +21,13 @@
       <span v-html="$config.footer" />
     </div>
     <div class="line" v-if="$store.getters.userInfo.roletype === 'Admin'">
-      CloudStack {{ $store.getters.features.cloudstackversion }}
+      ABLESTACK Allo (v1.0.0) - Powered By Apache CloudStack
+      <!-- CloudStack {{ $store.getters.features.cloudstackversion }}
       <a-divider type="vertical" />
       <a href="https://github.com/apache/cloudstack/issues/new" target="_blank">
         <a-icon type="github"/>
         {{ $t('label.report.bug') }}
-      </a>
+      </a> -->
     </div>
   </div>
 </template>

--- a/ui/src/components/page/GlobalFooter.vue
+++ b/ui/src/components/page/GlobalFooter.vue
@@ -26,7 +26,7 @@
       <a href="https://github.com/ablecloud-team/ablestack-cloud/issues/new" target="_blank">
         <a-icon type="github"/>
         {{ $t('label.report.bug') }}
-      </a> -->
+      </a>
     </div>
   </div>
 </template>

--- a/ui/src/components/page/GlobalFooter.vue
+++ b/ui/src/components/page/GlobalFooter.vue
@@ -22,9 +22,8 @@
     </div>
     <div class="line" v-if="$store.getters.userInfo.roletype === 'Admin'">
       ABLESTACK Allo (v1.0.0) - Powered By Apache CloudStack
-      <!-- CloudStack {{ $store.getters.features.cloudstackversion }}
       <a-divider type="vertical" />
-      <a href="https://github.com/apache/cloudstack/issues/new" target="_blank">
+      <a href="https://github.com/ablecloud-team/ablestack-cloud/issues/new" target="_blank">
         <a-icon type="github"/>
         {{ $t('label.report.bug') }}
       </a> -->


### PR DESCRIPTION
#5 
ABLESTACK 대시보드 하단에 아래와 같은 copyright 및 version 정보 추가

> Copyright (c) 2021, ABLECLOUD.Co.Ltd
> ABLESTACK Allo (v1.0.0) - Powered By Apache CloudStack Report Issue 