### PR TITLE
RBD primary storage 연결시 + 및 / 기호를 -와 _ 로 변경하는 로직 개선

### DIFF
--- a/ui/src/views/infra/AddPrimaryStorage.vue
+++ b/ui/src/views/infra/AddPrimaryStorage.vue
@@ -547,8 +547,8 @@ export default {
       /*  Replace the + and / symbols by - and _ to have URL-safe base64 going to the API
           It's hacky, but otherwise we'll confuse java.net.URI which splits the incoming URI
       */
-      secret = secret.replace('+', '-')
-      secret = secret.replace('/', '_')
+      secret = secret.replace(/\+/g, '-')
+      secret = secret.replace(/\//g, '_')
       if (id !== null && secret !== null) {
         monitor = id + ':' + secret + '@' + monitor
       }

--- a/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
+++ b/ui/src/views/infra/zone/ZoneWizardLaunchZone.vue
@@ -2091,8 +2091,8 @@ export default {
     },
     rbdURL (monitor, pool, id, secret) {
       let url
-      secret = secret.replace('+', '-')
-      secret = secret.replace('/', '_')
+      secret = secret.replace(/\+/g, '-')
+      secret = secret.replace(/\//g, '_')
       if (id != null && secret != null) {
         monitor = id + ':' + secret + '@' + monitor
       }


### PR DESCRIPTION
Replace multiple + and / symbols by - and _ to have URL-safe base64 going to the API

### PR 설명

When adding RBD primary storage, if secret contains only one "+"  and one "/" symbol, It replace to "-" and "_" correctly.
However, if secret contains many "+" and "/" symbols, it replace only one first symbol to "-" and "_".

RBD primary storage를 연결시 secret에 하나의 "+"와 "/"기호가 포함된 경우 정상적으로 "-" 와 "_"로 변경합니다.
하지만 다수의 "+"와 "/" 기호가 들어온 경우 정상적으로 처리하지 못하고 처음 발견한 문자들만 변경하던 문제를 해결하였습니다.

### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [x] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [ ] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [ ] 주요 기능/개선
- [x] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [x] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [ ] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷


### 테스트 방법 및 결과
![image](https://user-images.githubusercontent.com/13939146/138049596-0b3c1515-5931-4590-be87-5ff9bfd1801d.png)

