### PR TITLE
Desktop WorksVM 배포시 Userdata 변경, Cluster 상세조회 잘못된 정보 표기 수정

### DIFF
--- a/plugins/integrations/desktop-service/src/main/java/com/cloud/desktop/cluster/DesktopClusterManagerImpl.java
+++ b/plugins/integrations/desktop-service/src/main/java/com/cloud/desktop/cluster/DesktopClusterManagerImpl.java
@@ -73,7 +73,6 @@ import com.cloud.network.Network;
 import com.cloud.network.Network.GuestType;
 import com.cloud.network.NetworkService;
 import com.cloud.network.dao.NetworkDao;
-import com.cloud.network.dao.IPAddressVO;
 import com.cloud.network.dao.IPAddressDao;
 import com.cloud.network.dao.NetworkVO;
 import com.cloud.service.dao.ServiceOfferingDao;
@@ -232,13 +231,6 @@ public class DesktopClusterManagerImpl extends ManagerBase implements DesktopClu
         response.setNetworkId(ntwk.getUuid());
         response.setAssociatedNetworkName(ntwk.getName());
         response.setNetworkType(ntwk.getGuestType());
-        if (ntwk.getGuestType() == Network.GuestType.Isolated) {
-            List<IPAddressVO> ipAddresses = ipAddressDao.listByAssociatedNetwork(ntwk.getId(), true);
-            if (ipAddresses != null && ipAddresses.size() == 1) {
-                response.setIpAddress(ipAddresses.get(0).getAddress().addr());
-                response.setIpAddressId(ipAddresses.get(0).getUuid());
-            }
-        }
 
         List<UserVmResponse> controlVmResponses = new ArrayList<UserVmResponse>();
         List<UserVmResponse> desktopVmResponses = new ArrayList<UserVmResponse>();

--- a/plugins/integrations/desktop-service/src/main/java/com/cloud/desktop/cluster/actionworkers/DesktopClusterResourceModifierActionWorker.java
+++ b/plugins/integrations/desktop-service/src/main/java/com/cloud/desktop/cluster/actionworkers/DesktopClusterResourceModifierActionWorker.java
@@ -70,6 +70,7 @@ import com.cloud.utils.exception.ExecutionException;
 import com.cloud.vm.UserVmManager;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.dao.VMInstanceDao;
+import com.cloud.api.query.dao.UserAccountJoinDao;
 import com.google.common.base.Strings;
 
 import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
@@ -108,6 +109,8 @@ public class DesktopClusterResourceModifierActionWorker extends DesktopClusterAc
     protected VolumeDao volumeDao;
     @Inject
     protected IPAddressDao ipAddressDao;
+    @Inject
+    protected UserAccountJoinDao userAccountJoinDao;
 
     protected DesktopClusterResourceModifierActionWorker(final DesktopCluster desktopCluster, final DesktopClusterManagerImpl clusterManager) {
         super(desktopCluster, clusterManager);

--- a/plugins/integrations/desktop-service/src/main/java/com/cloud/desktop/cluster/actionworkers/DesktopClusterStartWorker.java
+++ b/plugins/integrations/desktop-service/src/main/java/com/cloud/desktop/cluster/actionworkers/DesktopClusterStartWorker.java
@@ -65,6 +65,7 @@ import com.cloud.desktop.version.DesktopControllerVersion;
 import com.cloud.vm.ReservationContext;
 import com.cloud.vm.ReservationContextImpl;
 import com.cloud.vm.VirtualMachine;
+import com.cloud.api.query.vo.UserAccountJoinVO;
 import com.google.common.base.Strings;
 
 public class DesktopClusterStartWorker extends DesktopClusterResourceModifierActionWorker {
@@ -106,12 +107,13 @@ public class DesktopClusterStartWorker extends DesktopClusterResourceModifierAct
         final String zoneUuid = "{{ zone_id }}";
         final String networkId = "{{ network_id }}";
         final String accountName = "{{ account_name }}";
-        final String accountUuid = "{{ account_uuid }}";
+        final String domainUuid = "{{ domain_uuid }}";
         final String apiKey = "{{ api_key }}";
         final String secretKey = "{{ secret_key }}";
         final String moldIp = "{{ mold_ip }}";
         final String moldPort = "{{ mold_port }}";
         final String moldProtocol = "{{ mold_protocol }}";
+        List<UserAccountJoinVO> domain = userAccountJoinDao.searchByAccountId(owner.getId());
         desktopClusterWorksConfig = desktopClusterWorksConfig.replace(clusterName, desktopCluster.getName());
         desktopClusterWorksConfig = desktopClusterWorksConfig.replace(domainName, desktopCluster.getAdDomainName());
         desktopClusterWorksConfig = desktopClusterWorksConfig.replace(worksIp, desktopCluster.getWorksIp());
@@ -119,7 +121,7 @@ public class DesktopClusterStartWorker extends DesktopClusterResourceModifierAct
         desktopClusterWorksConfig = desktopClusterWorksConfig.replace(zoneUuid, zone.getUuid());
         desktopClusterWorksConfig = desktopClusterWorksConfig.replace(networkId, Long.toString(desktopCluster.getNetworkId()));
         desktopClusterWorksConfig = desktopClusterWorksConfig.replace(accountName, owner.getAccountName());
-        desktopClusterWorksConfig = desktopClusterWorksConfig.replace(accountUuid, owner.getUuid());
+        desktopClusterWorksConfig = desktopClusterWorksConfig.replace(domainUuid, domain.get(0).getDomainUuid());
         desktopClusterWorksConfig = desktopClusterWorksConfig.replace(apiKey, keys[0]);
         desktopClusterWorksConfig = desktopClusterWorksConfig.replace(secretKey, keys[1]);
         desktopClusterWorksConfig = desktopClusterWorksConfig.replace(moldIp, managementIp);

--- a/plugins/integrations/desktop-service/src/main/resources/conf/works
+++ b/plugins/integrations/desktop-service/src/main/resources/conf/works
@@ -1,6 +1,6 @@
 {
 	"mold.default.domain.account":"{{ account_name }}",
-	"mold.default.domain.id":"{{ account_uuid }}",
+	"mold.default.domain.id":"{{ domain_uuid }}",
 	"mold.default.api.key":"{{ api_key }}",
 	"mold.default.secret.key":"{{ secret_key }}",
 	"mold.default.protocol":"{{ mold_protocol }}",


### PR DESCRIPTION
### PR 설명

Desktop WorksVM 배포시 Userdata 변경 및 Desktop Cluster 상세 정보에 잘못된 정보 표기 수정에 관한 PR입니다.

- Desktop WorksVM 배포시전달하는 Userdata는 account_uuid 에서 domain_uuid로 변경하였습니다.
- Desktop Cluster 상세 정보에 IP Address 항목을 제외하였습니다.

<!--- 변경 사항에 대해 자세하게 설명하십시오. 그리고 변경사항을 어떻게 실행하는지도 설명합니다. -->

<!-- 새로운 기능에 대한 PR인 경우, 타당성 조사(FS) 및 디자인 컨셉(DS) 등에 대한 위키 또는 문서 등을 링크합니다. -->
<!-- 버그 수정에 대한 PR인 경우, 재현을 위한 과정과 기대 실행 및 실제 실행 결과에 대한 내용을 설명합니다. -->

<!-- "Fixes #<id>"를 사용하면 해당 이슈 및 PR이 관련 이슈/PR로 등록되어 PR이 Merge 될 때 자동으로 종료됩니다. -->
<!-- 여려 개의 이슈 또는 PR을 지정하고자 하는 경우, 여러 개의 "Fixes #<id>"를 작성합니다. -->
<!-- Fixes # -->

### 이슈

- [x] #97 
- [x] #99 

### 변경 구분

- [x] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [x] 소규모 기능/개선

