### PR TITLE
Ablestack cerato tpm 설정 기능 추가

### DIFF
--- a/agent/bindir/libvirtqemuhook.in
+++ b/agent/bindir/libvirtqemuhook.in
@@ -191,7 +191,8 @@ if __name__ == '__main__':
         sys.exit(0)
 
     # For docs refer https://libvirt.org/hooks.html#qemu
-    logger.debug("Executing qemu hook with args: %s" % sys.argv)
+    logger.info("Executing qemu hook with args: %s" % sys.argv)
+    logger.info("Executing qemu hook with xml: %s" % parse(sys.stdin).toxml())
     action, status = sys.argv[2:4]
 
     if action not in validQemuActions:

--- a/api/src/main/java/com/cloud/agent/api/to/VirtualMachineTO.java
+++ b/api/src/main/java/com/cloud/agent/api/to/VirtualMachineTO.java
@@ -65,6 +65,7 @@ public class VirtualMachineTO {
     String bootMode;
     boolean enterHardwareSetup;
 
+    String tpmVersion;
     DiskTO[] disks;
     NicTO[] nics;
     GPUDeviceTO gpuDevice;
@@ -401,6 +402,14 @@ public class VirtualMachineTO {
     public String getBootMode() { return bootMode; }
 
     public void setBootMode(String bootMode) { this.bootMode = bootMode; }
+
+    public String getTpmVersion() {
+        return tpmVersion;
+    }
+
+    public void setTpmVersion(String tpmVersion) {
+        this.tpmVersion = tpmVersion;
+    }
 
     public boolean isEnterHardwareSetup() {
         return enterHardwareSetup;

--- a/api/src/main/java/com/cloud/host/Host.java
+++ b/api/src/main/java/com/cloud/host/Host.java
@@ -54,6 +54,10 @@ public interface Host extends StateObject<Status>, Identity, Partition, HAResour
     }
     public static final String HOST_UEFI_ENABLE = "host.uefi.enable";
 
+    public static final String HOST_IOURING_ENABLE = "host.iouring.enable";
+
+    public static final String HOST_TPM_ENABLE = "host.tpm.enable";
+
     /**
      * @return name of the machine.
      */

--- a/api/src/main/java/com/cloud/host/Host.java
+++ b/api/src/main/java/com/cloud/host/Host.java
@@ -54,8 +54,6 @@ public interface Host extends StateObject<Status>, Identity, Partition, HAResour
     }
     public static final String HOST_UEFI_ENABLE = "host.uefi.enable";
 
-    public static final String HOST_IOURING_ENABLE = "host.iouring.enable";
-
     public static final String HOST_TPM_ENABLE = "host.tpm.enable";
 
     /**

--- a/api/src/main/java/com/cloud/vm/VirtualMachineProfile.java
+++ b/api/src/main/java/com/cloud/vm/VirtualMachineProfile.java
@@ -71,7 +71,7 @@ public interface VirtualMachineProfile {
         public static final Param HaTag = new Param("HaTag");
         public static final Param HaOperation = new Param("HaOperation");
         public static final Param UefiFlag = new Param("UefiFlag");
-        public static final Param TpmFlag = new Param("TpmFlag");
+        public static final Param TpmFlag = new Param("tpm");
         public static final Param BootMode = new Param("BootMode");
         public static final Param BootType = new Param("BootType");
         public static final Param BootIntoSetup = new Param("enterHardwareSetup");

--- a/api/src/main/java/com/cloud/vm/VirtualMachineProfile.java
+++ b/api/src/main/java/com/cloud/vm/VirtualMachineProfile.java
@@ -71,7 +71,7 @@ public interface VirtualMachineProfile {
         public static final Param HaTag = new Param("HaTag");
         public static final Param HaOperation = new Param("HaOperation");
         public static final Param UefiFlag = new Param("UefiFlag");
-        public static final Param TpmFlag = new Param("tpm");
+        public static final Param TpmFlag = new Param("tpmVersion");
         public static final Param BootMode = new Param("BootMode");
         public static final Param BootType = new Param("BootType");
         public static final Param BootIntoSetup = new Param("enterHardwareSetup");

--- a/api/src/main/java/com/cloud/vm/VirtualMachineProfile.java
+++ b/api/src/main/java/com/cloud/vm/VirtualMachineProfile.java
@@ -71,7 +71,6 @@ public interface VirtualMachineProfile {
         public static final Param HaTag = new Param("HaTag");
         public static final Param HaOperation = new Param("HaOperation");
         public static final Param UefiFlag = new Param("UefiFlag");
-        public static final Param IouringFlag = new Param("IouringFlag");
         public static final Param TpmFlag = new Param("TpmFlag");
         public static final Param BootMode = new Param("BootMode");
         public static final Param BootType = new Param("BootType");

--- a/api/src/main/java/com/cloud/vm/VirtualMachineProfile.java
+++ b/api/src/main/java/com/cloud/vm/VirtualMachineProfile.java
@@ -71,7 +71,7 @@ public interface VirtualMachineProfile {
         public static final Param HaTag = new Param("HaTag");
         public static final Param HaOperation = new Param("HaOperation");
         public static final Param UefiFlag = new Param("UefiFlag");
-        public static final Param TpmFlag = new Param("tpmVersion");
+        public static final Param TpmVersion = new Param("tpmVersion");
         public static final Param BootMode = new Param("BootMode");
         public static final Param BootType = new Param("BootType");
         public static final Param BootIntoSetup = new Param("enterHardwareSetup");

--- a/api/src/main/java/com/cloud/vm/VirtualMachineProfile.java
+++ b/api/src/main/java/com/cloud/vm/VirtualMachineProfile.java
@@ -71,7 +71,7 @@ public interface VirtualMachineProfile {
         public static final Param HaTag = new Param("HaTag");
         public static final Param HaOperation = new Param("HaOperation");
         public static final Param UefiFlag = new Param("UefiFlag");
-        public static final Param TpmVersion = new Param("tpmVersion");
+        public static final Param TpmVersion = new Param("TpmVersion");
         public static final Param BootMode = new Param("BootMode");
         public static final Param BootType = new Param("BootType");
         public static final Param BootIntoSetup = new Param("enterHardwareSetup");

--- a/api/src/main/java/com/cloud/vm/VirtualMachineProfile.java
+++ b/api/src/main/java/com/cloud/vm/VirtualMachineProfile.java
@@ -71,6 +71,8 @@ public interface VirtualMachineProfile {
         public static final Param HaTag = new Param("HaTag");
         public static final Param HaOperation = new Param("HaOperation");
         public static final Param UefiFlag = new Param("UefiFlag");
+        public static final Param IouringFlag = new Param("IouringFlag");
+        public static final Param TpmFlag = new Param("TpmFlag");
         public static final Param BootMode = new Param("BootMode");
         public static final Param BootType = new Param("BootType");
         public static final Param BootIntoSetup = new Param("enterHardwareSetup");

--- a/api/src/main/java/com/cloud/vm/VmDetailConstants.java
+++ b/api/src/main/java/com/cloud/vm/VmDetailConstants.java
@@ -39,7 +39,7 @@ public interface VmDetailConstants {
     // KVM specific (internal)
     String KVM_VNC_PORT = "kvm.vnc.port";
     String KVM_VNC_ADDRESS = "kvm.vnc.address";
-
+    String TPM_VERSION = "tpmVersion";
     // KVM specific, custom virtual GPU hardware
     String VIDEO_HARDWARE = "video.hardware";
     String VIDEO_RAM = "video.ram";

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -929,7 +929,7 @@ public class ApiConstants {
 
     public static final String BOOT_TYPE = "boottype";
     public static final String BOOT_MODE = "bootmode";
-    public static final String TPM_VERSION = "tpmVersion";
+    public static final String TPM_VERSION = "tpmversion";
     public static final String BOOT_INTO_SETUP = "bootintosetup";
     public static final String DEPLOY_AS_IS = "deployasis";
     public static final String DEPLOY_AS_IS_DETAILS = "deployasisdetails";

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -966,13 +966,8 @@ public class ApiConstants {
     }
 
     public enum TpmVersion {
-        V2_0("V2_0"), V1_2("V1_2"), TPM("TPM"), NONE("NONE");
+        V2_0, V1_2, TPM, NONE;
 
-        String _type;
-
-        TpmVersion(String type) {
-            _type = type;
-        }
 
         @Override
         public String toString() {

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -930,7 +930,7 @@ public class ApiConstants {
     public static final String BOOT_TYPE = "boottype";
     public static final String BOOT_MODE = "bootmode";
     public static final String TPM_ENABLED = "tpmenabled";
-    public static final String TPM_VERSION = "tpm";
+    public static final String TPM_VERSION = "tpmVersion";
     public static final String BOOT_INTO_SETUP = "bootintosetup";
     public static final String DEPLOY_AS_IS = "deployasis";
     public static final String DEPLOY_AS_IS_DETAILS = "deployasisdetails";

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -929,6 +929,7 @@ public class ApiConstants {
 
     public static final String BOOT_TYPE = "boottype";
     public static final String BOOT_MODE = "bootmode";
+    public static final String TPM_ENABLED = "tpmenabled";
     public static final String BOOT_INTO_SETUP = "bootintosetup";
     public static final String DEPLOY_AS_IS = "deployasis";
     public static final String DEPLOY_AS_IS_DETAILS = "deployasisdetails";
@@ -956,6 +957,24 @@ public class ApiConstants {
 
     public enum BootMode {
         LEGACY, SECURE;
+
+        @Override
+        public String toString() {
+            return this.name();
+        }
+    }
+
+    public enum TpmEnabled {
+        TPM, NONE;
+
+        @Override
+        public String toString() {
+            return this.name();
+        }
+    }
+
+    public enum IoType {
+        IOURING, NATIVE;
 
         @Override
         public String toString() {

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -965,12 +965,12 @@ public class ApiConstants {
         }
     }
 
-    public enum TpmEnabled {
-        V2_0("V2_0"), V1_2("V1_2"), NONE("NONE");
+    public enum TpmVersion {
+        V2_0("V2_0"), V1_2("V1_2"), TPM("TPM"), NONE("NONE");
 
         String _type;
 
-        TpmEnabled(String type) {
+        TpmVersion(String type) {
             _type = type;
         }
 

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -929,7 +929,6 @@ public class ApiConstants {
 
     public static final String BOOT_TYPE = "boottype";
     public static final String BOOT_MODE = "bootmode";
-    public static final String TPM_ENABLED = "tpmenabled";
     public static final String TPM_VERSION = "tpmVersion";
     public static final String BOOT_INTO_SETUP = "bootintosetup";
     public static final String DEPLOY_AS_IS = "deployasis";

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -972,13 +972,16 @@ public class ApiConstants {
             return this.name();
         }
     }
-
-    public enum IoType {
-        IOURING, NATIVE;
+    public enum TpmVersion {
+        NONE, V1_2, V2_0;
 
         @Override
         public String toString() {
-            return this.name();
+            if (this.name().equals("V1_2"))
+                return "1.2";
+            else if (this.name().equals("V2_0"))
+                return "2.0";
+            return "NONE";
         }
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -930,6 +930,7 @@ public class ApiConstants {
     public static final String BOOT_TYPE = "boottype";
     public static final String BOOT_MODE = "bootmode";
     public static final String TPM_ENABLED = "tpmenabled";
+    public static final String TPM_VERSION = "tpmversion";
     public static final String BOOT_INTO_SETUP = "bootintosetup";
     public static final String DEPLOY_AS_IS = "deployasis";
     public static final String DEPLOY_AS_IS_DETAILS = "deployasisdetails";

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -930,7 +930,7 @@ public class ApiConstants {
     public static final String BOOT_TYPE = "boottype";
     public static final String BOOT_MODE = "bootmode";
     public static final String TPM_ENABLED = "tpmenabled";
-    public static final String TPM_VERSION = "tpmversion";
+    public static final String TPM_VERSION = "tpm";
     public static final String BOOT_INTO_SETUP = "bootintosetup";
     public static final String DEPLOY_AS_IS = "deployasis";
     public static final String DEPLOY_AS_IS_DETAILS = "deployasisdetails";

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -966,15 +966,13 @@ public class ApiConstants {
     }
 
     public enum TpmEnabled {
-        TPM, NONE;
+        V2_0("V2_0"), V1_2("V1_2"), NONE("NONE");
 
-        @Override
-        public String toString() {
-            return this.name();
+        String _type;
+
+        TpmEnabled(String type) {
+            _type = type;
         }
-    }
-    public enum TpmVersion {
-        NONE, V1_2, V2_0;
 
         @Override
         public String toString() {

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -126,7 +126,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
 
 
     @Parameter(name = ApiConstants.TPM_VERSION, type = CommandType.STRING, required = false, description = "Boot with TPM", since = "4.18.0.0")
-    private String tpmversion;
+    private String tpmVersion;
     //DataDisk information
     @ACL
     @Parameter(name = ApiConstants.DISK_OFFERING_ID, type = CommandType.UUID, entityType = DiskOfferingResponse.class, description = "the ID of the disk offering for the virtual machine. If the template is of ISO format,"
@@ -297,12 +297,13 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     }
 
     public ApiConstants.TpmVersion getTpmVersion() {
-        if (StringUtils.isNotBlank(tpmversion)) {
+        s_logger.debug(tpmVersion);
+        if (StringUtils.isNotBlank(tpmVersion)) {
             try {
-                String type = tpmversion.trim().toUpperCase();
+                String type = tpmVersion.trim().toUpperCase();
                 return ApiConstants.TpmVersion.valueOf(type);
             } catch (IllegalArgumentException e) {
-                String errMesg = "Invalid TpmVersion " + tpmversion + "Specified for vm " + getName()
+                String errMesg = "Invalid TpmVersion " + tpmVersion + "Specified for vm " + getName()
                         + " Valid values are: " + Arrays.toString(ApiConstants.BootType.values());
                 s_logger.warn(errMesg);
                 throw new InvalidParameterValueException(errMesg);
@@ -331,8 +332,11 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             customparameterMap.put("rootdisksize", rootdisksize.toString());
         }
 
-        s_logger.debug("tpmVersion:" + getTpmVersion().toString());
+        customparameterMap.forEach((strKey, strValue)->{
+            s_logger.debug( "[DeployVMCmd 336] customparameterMap ycyun: " + strKey + " : " + strValue );
+        });
         if (getTpmVersion() != null || getTpmVersion() != ApiConstants.TpmVersion.NONE){
+            s_logger.debug("tpmVersion:" + getTpmVersion().toString());
             customparameterMap.put("tpmVersion", getTpmVersion().toString());
         }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -337,6 +337,27 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
         return null;
     }
 
+    public ApiConstants.TpmEnabled getTpmEnabled() {
+        if (StringUtils.isNotBlank(bootMode)) {
+            try {
+                String mode = bootMode.trim().toUpperCase();
+                return ApiConstants.TpmEnabled.valueOf(mode);
+            } catch (IllegalArgumentException e) {
+                String msg = String.format("Invalid %s: %s specified for VM: %s. Valid values are: %s",
+                        ApiConstants.TPM_ENABLED, bootMode, getName(), Arrays.toString(ApiConstants.TpmEnabled.values()));
+                s_logger.error(msg);
+                throw new InvalidParameterValueException(msg);
+            }
+        }
+        if (ApiConstants.TpmEnabled.TPM.equals(getTpmEnabled())) {
+            String msg = String.format("%s must be specified for the VM with boot type: %s. Valid values are: %s",
+                    ApiConstants.TPM_ENABLED, getTpmEnabled(), Arrays.toString(ApiConstants.BootMode.values()));
+            s_logger.error(msg);
+            throw new InvalidParameterValueException(msg);
+        }
+        return null;
+    }
+
     public Map<String, String> getVmProperties() {
         Map<String, String> map = new HashMap<>();
         if (MapUtils.isNotEmpty(vAppProperties)) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -333,7 +333,10 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
         if (rootdisksize != null && !customparameterMap.containsKey("rootdisksize")) {
             customparameterMap.put("rootdisksize", rootdisksize.toString());
         }
-
+        for (Map.Entry<String,String> entry: customparameterMap.entrySet()) {
+            s_logger.debug( "[DeployVMCmd 337] details ycyun: " + entry.getKey() + " : " + entry.getValue() );
+            customparameterMap.put(entry.getKey(),entry.getValue());
+        }
         if (customparameterMap.containsKey(ApiConstants.TpmVersion.V1_2.toString())) {
             s_logger.debug("tpmVersion 1_2:" + customparameterMap.get(ApiConstants.TpmVersion.V1_2.toString()));
             customparameterMap.put("tpmVersion", customparameterMap.get(ApiConstants.TpmVersion.V1_2.toString()));

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -123,6 +123,12 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     @Parameter(name = ApiConstants.BOOT_INTO_SETUP, type = CommandType.BOOLEAN, required = false, description = "Boot into hardware setup or not (ignored if startVm = false, only valid for vmware)", since = "4.15.0.0")
     private Boolean bootIntoSetup;
 
+    @Parameter(name = ApiConstants.TPM_ENABLED, type = CommandType.STRING, required = false, description = "Boot with TPM", since = "4.18.0.0")
+    private String tpm_enabled;
+
+
+    @Parameter(name = ApiConstants.TPM_VERSION, type = CommandType.STRING, required = false, description = "Boot with TPM", since = "4.18.0.0")
+    private String tpm_version;
     //DataDisk information
     @ACL
     @Parameter(name = ApiConstants.DISK_OFFERING_ID, type = CommandType.UUID, entityType = DiskOfferingResponse.class, description = "the ID of the disk offering for the virtual machine. If the template is of ISO format,"
@@ -292,6 +298,21 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
         return null;
     }
 
+    public ApiConstants.TpmVersion getTpmVersion() {
+        if (StringUtils.isNotBlank(tpm_version)) {
+            try {
+                String type = tpm_version.trim().toUpperCase();
+                return ApiConstants.TpmVersion.valueOf(type);
+            } catch (IllegalArgumentException e) {
+                String errMesg = "Invalid TpmVersion " + tpm_version + "Specified for vm " + getName()
+                        + " Valid values are: " + Arrays.toString(ApiConstants.BootType.values());
+                s_logger.warn(errMesg);
+                throw new InvalidParameterValueException(errMesg);
+            }
+        }
+        return null;
+    }
+
     public Map<String, String> getDetails() {
         Map<String, String> customparameterMap = new HashMap<String, String>();
         if (details != null && details.size() != 0) {
@@ -338,20 +359,20 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     }
 
     public ApiConstants.TpmEnabled getTpmEnabled() {
-        if (StringUtils.isNotBlank(bootMode)) {
+        if (StringUtils.isNotBlank(tpm_enabled)) {
             try {
-                String mode = bootMode.trim().toUpperCase();
+                String mode = tpm_enabled.trim().toUpperCase();
                 return ApiConstants.TpmEnabled.valueOf(mode);
             } catch (IllegalArgumentException e) {
                 String msg = String.format("Invalid %s: %s specified for VM: %s. Valid values are: %s",
-                        ApiConstants.TPM_ENABLED, bootMode, getName(), Arrays.toString(ApiConstants.TpmEnabled.values()));
+                        ApiConstants.TPM_ENABLED, tpm_enabled, getName(), Arrays.toString(ApiConstants.TpmEnabled.values()));
                 s_logger.error(msg);
                 throw new InvalidParameterValueException(msg);
             }
         }
         if (ApiConstants.TpmEnabled.TPM.equals(getTpmEnabled())) {
             String msg = String.format("%s must be specified for the VM with boot type: %s. Valid values are: %s",
-                    ApiConstants.TPM_ENABLED, getTpmEnabled(), Arrays.toString(ApiConstants.BootMode.values()));
+                    ApiConstants.TPM_ENABLED, getTpmVersion(), Arrays.toString(ApiConstants.TpmEnabled.values()));
             s_logger.error(msg);
             throw new InvalidParameterValueException(msg);
         }

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -335,12 +335,23 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
         customparameterMap.forEach((strKey, strValue)->{
             s_logger.debug( "[DeployVMCmd 336] customparameterMap ycyun: " + strKey + " : " + strValue );
         });
-        if (customparameterMap.containsKey(ApiConstants.TpmVersion.V1_2.toString())
-                || customparameterMap.containsKey(ApiConstants.TpmVersion.V2_0.toString())
-                || customparameterMap.containsKey("tpmVersion")
-                || getTpmVersion() != null
-                || getTpmVersion() != ApiConstants.TpmVersion.NONE){
-            s_logger.debug("tpmVersion:" + getTpmVersion().toString());
+        if (customparameterMap.containsKey(ApiConstants.TpmVersion.V1_2.toString())) {
+            s_logger.debug("tpmVersion 1_2:" + customparameterMap.get(ApiConstants.TpmVersion.V1_2.toString()));
+            customparameterMap.put("tpmVersion", customparameterMap.get(ApiConstants.TpmVersion.V1_2.toString()));
+        }else if(customparameterMap.containsKey(ApiConstants.TpmVersion.V2_0.toString())){
+            s_logger.debug("tpmVersion 2_0:" + customparameterMap.get(ApiConstants.TpmVersion.V2_0.toString()));
+            customparameterMap.put("tpmVersion", customparameterMap.get(ApiConstants.TpmVersion.V2_0.toString()));
+
+        }else if(customparameterMap.containsKey("tpmVersion")){
+            s_logger.debug("tpmVersion key:" + customparameterMap.get("tpmVersion"));
+            customparameterMap.put("tpmVersion", customparameterMap.get("tpmVersion"));
+
+        }else if(getTpmVersion() != null){
+            s_logger.debug("tpmVersion null:" + getTpmVersion().toString());
+            customparameterMap.put("tpmVersion", getTpmVersion().toString());
+
+        }else if(getTpmVersion() != ApiConstants.TpmVersion.NONE){
+            s_logger.debug("tpmVersion get:" + getTpmVersion().toString());
             customparameterMap.put("tpmVersion", getTpmVersion().toString());
         }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -331,6 +331,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             customparameterMap.put("rootdisksize", rootdisksize.toString());
         }
 
+        s_logger.debug("tpmVersion:" + getTpmVersion().toString());
         if (getTpmVersion() != null || getTpmVersion() != ApiConstants.TpmVersion.NONE){
             customparameterMap.put("tpmVersion", getTpmVersion().toString());
         }

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -302,6 +302,10 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
         if (StringUtils.isNotBlank(tpmVersion)) {
             try {
                 String type = tpmVersion.trim().toUpperCase();
+                s_logger.debug("inTpmVersion ycyun: " + tpmVersion +
+                        " tpmVersion: " + StringUtils.isNotBlank(tpmVersion) +
+                        " type: " + type +
+                        " value: " + ApiConstants.TpmVersion.valueOf(type));
                 return ApiConstants.TpmVersion.valueOf(type);
             } catch (IllegalArgumentException e) {
                 String errMesg = "Invalid TpmVersion " + tpmVersion + "Specified for vm " + getName()

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -346,15 +346,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             s_logger.debug("tpmVersion key:" + customparameterMap.get("tpmVersion"));
             customparameterMap.put("tpmVersion", customparameterMap.get("tpmVersion"));
 
-        }else if(getTpmVersion() != null){
-            s_logger.debug("tpmVersion null:" + getTpmVersion().toString());
-            customparameterMap.put("tpmVersion", getTpmVersion().toString());
-
-        }else if(getTpmVersion() != ApiConstants.TpmVersion.NONE){
-            s_logger.debug("tpmVersion get:" + getTpmVersion().toString());
-            customparameterMap.put("tpmVersion", getTpmVersion().toString());
         }
-
         return customparameterMap;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -320,6 +320,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             while (iter.hasNext()) {
                 HashMap<String, String> value = (HashMap<String, String>)iter.next();
                 for (Map.Entry<String,String> entry: value.entrySet()) {
+                    s_logger.debug( "[DeployVMCmd 323] details ycyun: " + entry.getKey() + " : " + entry.getValue() );
                     customparameterMap.put(entry.getKey(),entry.getValue());
                 }
             }
@@ -333,7 +334,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
         }
 
         customparameterMap.forEach((strKey, strValue)->{
-            s_logger.debug( "[DeployVMCmd 336] customparameterMap ycyun: " + strKey + " : " + strValue );
+            s_logger.debug( "[DeployVMCmd 337] customparameterMap ycyun: " + strKey + " : " + strValue );
         });
         if (customparameterMap.containsKey(ApiConstants.TpmVersion.V1_2.toString())) {
             s_logger.debug("tpmVersion 1_2:" + customparameterMap.get(ApiConstants.TpmVersion.V1_2.toString()));

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -351,8 +351,8 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             s_logger.debug("tpmVersion key:" + customparameterMap.get("tpmVersion"));
             customparameterMap.put("tpmVersion", customparameterMap.get("tpmVersion"));
         }else if(getTpmVersion() != null){
-            s_logger.debug("tpmVersion getTpmVersion:" + customparameterMap.get("tpmVersion"));
-            customparameterMap.put("tpmVersion", customparameterMap.get("tpmVersion"));
+            s_logger.debug("tpmVersion getTpmVersion:" + getTpmVersion());
+            customparameterMap.put("tpmVersion", getTpmVersion().toString());
         }else{
             s_logger.debug("tpmVersion: null");
             customparameterMap.put("tpmVersion", "NONE");

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -123,8 +123,6 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     @Parameter(name = ApiConstants.BOOT_INTO_SETUP, type = CommandType.BOOLEAN, required = false, description = "Boot into hardware setup or not (ignored if startVm = false, only valid for vmware)", since = "4.15.0.0")
     private Boolean bootIntoSetup;
 
-    @Parameter(name = ApiConstants.TPM_ENABLED, type = CommandType.STRING, required = false, description = "Boot with TPM", since = "4.18.0.0")
-    private String tpmenabled;
 
 
     @Parameter(name = ApiConstants.TPM_VERSION, type = CommandType.STRING, required = false, description = "Boot with TPM", since = "4.18.0.0")
@@ -298,13 +296,13 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
         return null;
     }
 
-    public ApiConstants.TpmEnabled getTpmVersion() {
-        if (StringUtils.isNotBlank(tpmenabled)) {
+    public ApiConstants.TpmVersion getTpmVersion() {
+        if (StringUtils.isNotBlank(tpmversion)) {
             try {
-                String type = tpmenabled.trim().toUpperCase();
-                return ApiConstants.TpmEnabled.valueOf(type);
+                String type = tpmversion.trim().toUpperCase();
+                return ApiConstants.TpmVersion.valueOf(type);
             } catch (IllegalArgumentException e) {
-                String errMesg = "Invalid TpmVersion " + tpmenabled + "Specified for vm " + getName()
+                String errMesg = "Invalid TpmVersion " + tpmversion + "Specified for vm " + getName()
                         + " Valid values are: " + Arrays.toString(ApiConstants.BootType.values());
                 s_logger.warn(errMesg);
                 throw new InvalidParameterValueException(errMesg);
@@ -333,8 +331,8 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             customparameterMap.put("rootdisksize", rootdisksize.toString());
         }
 
-        if (getTpmEnabled() != null){
-            customparameterMap.put(getTpmEnabled().toString(), getTpmVersion().toString());
+        if (getTpmVersion() != null || getTpmVersion() != ApiConstants.TpmVersion.NONE){
+            customparameterMap.put("tpmVersion", getTpmVersion().toString());
         }
 
         return customparameterMap;
@@ -362,28 +360,6 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
         return null;
     }
 
-    public ApiConstants.TpmEnabled getTpmEnabled() {
-        if (StringUtils.isNotBlank(tpmversion)) {
-            try {
-                String mode = tpmversion.trim().toUpperCase();
-                return ApiConstants.TpmEnabled.valueOf(mode);
-            } catch (IllegalArgumentException e) {
-                String msg = String.format("Invalid %s: %s specified for VM: %s. Valid values are: %s",
-                        ApiConstants.TPM_ENABLED, tpmversion, getName(), Arrays.toString(ApiConstants.TpmEnabled.values()));
-                s_logger.error(msg);
-                throw new InvalidParameterValueException(msg);
-            }
-        }
-        if (ApiConstants.TpmEnabled.V1_2.equals(getTpmVersion()) ||
-                ApiConstants.TpmEnabled.V2_0.equals(getTpmVersion()) ||
-                ApiConstants.TpmEnabled.NONE.equals(getTpmVersion())) {
-            String msg = String.format("%s must be specified for the VM with boot type: %s. Valid values are: %s",
-                    ApiConstants.TPM_ENABLED, getTpmVersion(), Arrays.toString(ApiConstants.TpmEnabled.values()));
-            s_logger.error(msg);
-            throw new InvalidParameterValueException(msg);
-        }
-        return null;
-    }
 
     public Map<String, String> getVmProperties() {
         Map<String, String> map = new HashMap<>();

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -351,7 +351,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             customparameterMap.put("tpmVersion", customparameterMap.get("tpmVersion"));
         }else{
             s_logger.debug("tpmVersion: null");
-            customparameterMap.put("tpmVersion", "None");
+            customparameterMap.put("tpmVersion", "NONE");
         }
 
         customparameterMap.forEach((strKey, strValue)->{

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -333,6 +333,10 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             customparameterMap.put("rootdisksize", rootdisksize.toString());
         }
 
+        if (getTpmEnabled() != null){
+            customparameterMap.put(getTpmEnabled().toString(), getTpmVersion().toString());
+        }
+
         return customparameterMap;
     }
 
@@ -370,7 +374,9 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
                 throw new InvalidParameterValueException(msg);
             }
         }
-        if (ApiConstants.TpmEnabled.TPM.equals(getTpmEnabled())) {
+        if (ApiConstants.TpmVersion.V1_2.equals(getTpmVersion()) ||
+                ApiConstants.TpmVersion.V2_0.equals(getTpmVersion()) ||
+                ApiConstants.TpmVersion.NONE.equals(getTpmVersion())) {
             String msg = String.format("%s must be specified for the VM with boot type: %s. Valid values are: %s",
                     ApiConstants.TPM_ENABLED, getTpmVersion(), Arrays.toString(ApiConstants.TpmEnabled.values()));
             s_logger.error(msg);

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -297,7 +297,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     }
 
     public ApiConstants.TpmVersion getTpmVersion() {
-        s_logger.debug(tpmVersion);
+        s_logger.debug("inTpmVersion ycyun: " + tpmVersion);
         if (StringUtils.isNotBlank(tpmVersion)) {
             try {
                 String type = tpmVersion.trim().toUpperCase();
@@ -347,6 +347,9 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             s_logger.debug("tpmVersion key:" + customparameterMap.get("tpmVersion"));
             customparameterMap.put("tpmVersion", customparameterMap.get("tpmVersion"));
 
+        }else if(getTpmVersion() != null){
+            s_logger.debug("tpmVersion getTpmVersion:" + customparameterMap.get("tpmVersion"));
+            customparameterMap.put("tpmVersion", customparameterMap.get("tpmVersion"));
         }
         return customparameterMap;
     }

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -341,10 +341,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             s_logger.debug( "[DeployVMCmd 337] details ycyun: " + entry.getKey() + " : " + entry.getValue() );
             customparameterMap.put(entry.getKey(),entry.getValue());
         }
-        if (customparameterMap.containsKey(ApiConstants.TpmVersion.V1_2.toString())) {
-            s_logger.debug("tpmVersion 1_2:" + customparameterMap.get(ApiConstants.TpmVersion.V1_2.toString()));
-            customparameterMap.put("tpmVersion", customparameterMap.get(ApiConstants.TpmVersion.V1_2.toString()));
-        }else if(customparameterMap.containsKey(ApiConstants.TpmVersion.V2_0.toString())){
+        if(customparameterMap.containsKey(ApiConstants.TpmVersion.V2_0.toString())){
             s_logger.debug("tpmVersion 2_0:" + customparameterMap.get(ApiConstants.TpmVersion.V2_0.toString()));
             customparameterMap.put("tpmVersion", customparameterMap.get(ApiConstants.TpmVersion.V2_0.toString()));
         }else if(customparameterMap.containsKey("tpmVersion")){

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -124,11 +124,11 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     private Boolean bootIntoSetup;
 
     @Parameter(name = ApiConstants.TPM_ENABLED, type = CommandType.STRING, required = false, description = "Boot with TPM", since = "4.18.0.0")
-    private String tpm_enabled;
+    private String tpmenabled;
 
 
     @Parameter(name = ApiConstants.TPM_VERSION, type = CommandType.STRING, required = false, description = "Boot with TPM", since = "4.18.0.0")
-    private String tpm_version;
+    private String tpmversion;
     //DataDisk information
     @ACL
     @Parameter(name = ApiConstants.DISK_OFFERING_ID, type = CommandType.UUID, entityType = DiskOfferingResponse.class, description = "the ID of the disk offering for the virtual machine. If the template is of ISO format,"
@@ -299,12 +299,12 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     }
 
     public ApiConstants.TpmVersion getTpmVersion() {
-        if (StringUtils.isNotBlank(tpm_version)) {
+        if (StringUtils.isNotBlank(tpmenabled)) {
             try {
-                String type = tpm_version.trim().toUpperCase();
+                String type = tpmenabled.trim().toUpperCase();
                 return ApiConstants.TpmVersion.valueOf(type);
             } catch (IllegalArgumentException e) {
-                String errMesg = "Invalid TpmVersion " + tpm_version + "Specified for vm " + getName()
+                String errMesg = "Invalid TpmVersion " + tpmenabled + "Specified for vm " + getName()
                         + " Valid values are: " + Arrays.toString(ApiConstants.BootType.values());
                 s_logger.warn(errMesg);
                 throw new InvalidParameterValueException(errMesg);
@@ -359,13 +359,13 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     }
 
     public ApiConstants.TpmEnabled getTpmEnabled() {
-        if (StringUtils.isNotBlank(tpm_enabled)) {
+        if (StringUtils.isNotBlank(tpmversion)) {
             try {
-                String mode = tpm_enabled.trim().toUpperCase();
+                String mode = tpmversion.trim().toUpperCase();
                 return ApiConstants.TpmEnabled.valueOf(mode);
             } catch (IllegalArgumentException e) {
                 String msg = String.format("Invalid %s: %s specified for VM: %s. Valid values are: %s",
-                        ApiConstants.TPM_ENABLED, tpm_enabled, getName(), Arrays.toString(ApiConstants.TpmEnabled.values()));
+                        ApiConstants.TPM_ENABLED, tpmversion, getName(), Arrays.toString(ApiConstants.TpmEnabled.values()));
                 s_logger.error(msg);
                 throw new InvalidParameterValueException(msg);
             }

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -335,7 +335,11 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
         customparameterMap.forEach((strKey, strValue)->{
             s_logger.debug( "[DeployVMCmd 336] customparameterMap ycyun: " + strKey + " : " + strValue );
         });
-        if (getTpmVersion() != null || getTpmVersion() != ApiConstants.TpmVersion.NONE){
+        if (customparameterMap.containsKey(ApiConstants.TpmVersion.V1_2.toString())
+                || customparameterMap.containsKey(ApiConstants.TpmVersion.V2_0.toString())
+                || customparameterMap.containsKey("tpmVersion")
+                || getTpmVersion() != null
+                || getTpmVersion() != ApiConstants.TpmVersion.NONE){
             s_logger.debug("tpmVersion:" + getTpmVersion().toString());
             customparameterMap.put("tpmVersion", getTpmVersion().toString());
         }

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -298,11 +298,11 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
         return null;
     }
 
-    public ApiConstants.TpmVersion getTpmVersion() {
+    public ApiConstants.TpmEnabled getTpmVersion() {
         if (StringUtils.isNotBlank(tpmenabled)) {
             try {
                 String type = tpmenabled.trim().toUpperCase();
-                return ApiConstants.TpmVersion.valueOf(type);
+                return ApiConstants.TpmEnabled.valueOf(type);
             } catch (IllegalArgumentException e) {
                 String errMesg = "Invalid TpmVersion " + tpmenabled + "Specified for vm " + getName()
                         + " Valid values are: " + Arrays.toString(ApiConstants.BootType.values());
@@ -374,9 +374,9 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
                 throw new InvalidParameterValueException(msg);
             }
         }
-        if (ApiConstants.TpmVersion.V1_2.equals(getTpmVersion()) ||
-                ApiConstants.TpmVersion.V2_0.equals(getTpmVersion()) ||
-                ApiConstants.TpmVersion.NONE.equals(getTpmVersion())) {
+        if (ApiConstants.TpmEnabled.V1_2.equals(getTpmVersion()) ||
+                ApiConstants.TpmEnabled.V2_0.equals(getTpmVersion()) ||
+                ApiConstants.TpmEnabled.NONE.equals(getTpmVersion())) {
             String msg = String.format("%s must be specified for the VM with boot type: %s. Valid values are: %s",
                     ApiConstants.TPM_ENABLED, getTpmVersion(), Arrays.toString(ApiConstants.TpmEnabled.values()));
             s_logger.error(msg);

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -334,24 +334,26 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             customparameterMap.put("rootdisksize", rootdisksize.toString());
         }
 
-        customparameterMap.forEach((strKey, strValue)->{
-            s_logger.debug( "[DeployVMCmd 337] customparameterMap ycyun: " + strKey + " : " + strValue );
-        });
         if (customparameterMap.containsKey(ApiConstants.TpmVersion.V1_2.toString())) {
             s_logger.debug("tpmVersion 1_2:" + customparameterMap.get(ApiConstants.TpmVersion.V1_2.toString()));
             customparameterMap.put("tpmVersion", customparameterMap.get(ApiConstants.TpmVersion.V1_2.toString()));
         }else if(customparameterMap.containsKey(ApiConstants.TpmVersion.V2_0.toString())){
             s_logger.debug("tpmVersion 2_0:" + customparameterMap.get(ApiConstants.TpmVersion.V2_0.toString()));
             customparameterMap.put("tpmVersion", customparameterMap.get(ApiConstants.TpmVersion.V2_0.toString()));
-
         }else if(customparameterMap.containsKey("tpmVersion")){
             s_logger.debug("tpmVersion key:" + customparameterMap.get("tpmVersion"));
             customparameterMap.put("tpmVersion", customparameterMap.get("tpmVersion"));
-
         }else if(getTpmVersion() != null){
             s_logger.debug("tpmVersion getTpmVersion:" + customparameterMap.get("tpmVersion"));
             customparameterMap.put("tpmVersion", customparameterMap.get("tpmVersion"));
+        }else{
+            s_logger.debug("tpmVersion: null");
+            customparameterMap.put("tpmVersion", "None");
         }
+
+        customparameterMap.forEach((strKey, strValue)->{
+            s_logger.debug( "[DeployVMCmd 337] customparameterMap ycyun: " + strKey + " : " + strValue );
+        });
         return customparameterMap;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -282,7 +282,6 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     }
 
     public ApiConstants.BootType getBootType() {
-        s_logger.debug("inBootType ycyun: " + bootType + " bootType: " + StringUtils.isNotBlank(bootType));
         if (StringUtils.isNotBlank(bootType)) {
             try {
                 String type = bootType.trim().toUpperCase();
@@ -298,14 +297,9 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     }
 
     public ApiConstants.TpmVersion getTpmVersion() {
-        s_logger.debug("inTpmVersion ycyun: " + tpmVersion + " tpmVersion: " + StringUtils.isNotBlank(tpmVersion));
         if (StringUtils.isNotBlank(tpmVersion)) {
             try {
                 String type = tpmVersion.trim().toUpperCase();
-                s_logger.debug("inTpmVersion ycyun: " + tpmVersion +
-                        " tpmVersion: " + StringUtils.isNotBlank(tpmVersion) +
-                        " type: " + type +
-                        " value: " + ApiConstants.TpmVersion.valueOf(type));
                 return ApiConstants.TpmVersion.valueOf(type);
             } catch (IllegalArgumentException e) {
                 String errMesg = "Invalid TpmVersion " + tpmVersion + "Specified for vm " + getName()
@@ -325,7 +319,6 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             while (iter.hasNext()) {
                 HashMap<String, String> value = (HashMap<String, String>)iter.next();
                 for (Map.Entry<String,String> entry: value.entrySet()) {
-                    s_logger.debug( "[DeployVMCmd 323] details ycyun: " + entry.getKey() + " : " + entry.getValue() );
                     customparameterMap.put(entry.getKey(),entry.getValue());
                 }
             }
@@ -338,26 +331,18 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             customparameterMap.put("rootdisksize", rootdisksize.toString());
         }
         for (Map.Entry<String,String> entry: customparameterMap.entrySet()) {
-            s_logger.debug( "[DeployVMCmd 337] details ycyun: " + entry.getKey() + " : " + entry.getValue() );
             customparameterMap.put(entry.getKey(),entry.getValue());
         }
         if(customparameterMap.containsKey(ApiConstants.TpmVersion.V2_0.toString())){
-            s_logger.debug("tpmVersion 2_0:" + customparameterMap.get(ApiConstants.TpmVersion.V2_0.toString()));
             customparameterMap.put("tpmVersion", customparameterMap.get(ApiConstants.TpmVersion.V2_0.toString()));
         }else if(customparameterMap.containsKey("tpmVersion")){
-            s_logger.debug("tpmVersion key:" + customparameterMap.get("tpmVersion"));
             customparameterMap.put("tpmVersion", customparameterMap.get("tpmVersion"));
         }else if(getTpmVersion() != null){
-            s_logger.debug("tpmVersion getTpmVersion:" + getTpmVersion());
             customparameterMap.put("tpmVersion", getTpmVersion().toString());
         }else{
-            s_logger.debug("tpmVersion: null");
             customparameterMap.put("tpmVersion", "NONE");
         }
 
-        customparameterMap.forEach((strKey, strValue)->{
-            s_logger.debug( "[DeployVMCmd 337] customparameterMap ycyun: " + strKey + " : " + strValue );
-        });
         return customparameterMap;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -282,6 +282,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     }
 
     public ApiConstants.BootType getBootType() {
+        s_logger.debug("inBootType ycyun: " + bootType + " bootType: " + StringUtils.isNotBlank(bootType));
         if (StringUtils.isNotBlank(bootType)) {
             try {
                 String type = bootType.trim().toUpperCase();
@@ -297,7 +298,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     }
 
     public ApiConstants.TpmVersion getTpmVersion() {
-        s_logger.debug("inTpmVersion ycyun: " + tpmVersion);
+        s_logger.debug("inTpmVersion ycyun: " + tpmVersion + " tpmVersion: " + StringUtils.isNotBlank(tpmVersion));
         if (StringUtils.isNotBlank(tpmVersion)) {
             try {
                 String type = tpmVersion.trim().toUpperCase();

--- a/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
@@ -270,7 +270,6 @@ public class HostResponse extends BaseResponseWithAnnotations {
     @Param(description = "true if the host has capability to support UEFI boot")
     private Boolean uefiCapabilty;
     private boolean tpmCapabilty;
-    private ApiConstants.IoType ioType;
 
     @Override
     public String getObjectId() {
@@ -723,9 +722,5 @@ public class HostResponse extends BaseResponseWithAnnotations {
 
     public void setTpmCapabilty(Boolean hostCapability) {
         this.tpmCapabilty = hostCapability;
-    }
-
-    public void setIOType(ApiConstants.IoType hostCapability) {
-        this.ioType = hostCapability;
     }
 }

--- a/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
@@ -269,6 +269,8 @@ public class HostResponse extends BaseResponseWithAnnotations {
     @SerializedName("ueficapability")
     @Param(description = "true if the host has capability to support UEFI boot")
     private Boolean uefiCapabilty;
+    private boolean tpmCapabilty;
+    private ApiConstants.IoType ioType;
 
     @Override
     public String getObjectId() {
@@ -717,5 +719,13 @@ public class HostResponse extends BaseResponseWithAnnotations {
 
     public void setUefiCapabilty(Boolean hostCapability) {
         this.uefiCapabilty = hostCapability;
+    }
+
+    public void setTpmCapabilty(Boolean hostCapability) {
+        this.tpmCapabilty = hostCapability;
+    }
+
+    public void setIOType(ApiConstants.IoType hostCapability) {
+        this.ioType = hostCapability;
     }
 }

--- a/api/src/main/java/org/apache/cloudstack/api/response/UserVmResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UserVmResponse.java
@@ -320,6 +320,10 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
     @Param(description = "Guest vm Boot Type")
     private String bootType;
 
+    @SerializedName(ApiConstants.TPM_VERSION)
+    @Param(description = "Guest vm TPM Type")
+    private String tpmVersion;
+
     @SerializedName(ApiConstants.POOL_TYPE)
     @Param(description = "the pool type of the virtual machine", since = "4.16")
     private String poolType;
@@ -937,6 +941,11 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
     public void setBootMode(String bootMode) { this.bootMode = bootMode; }
 
     public String getPoolType() { return poolType; }
+
+
+    public String getTpmVersion() { return tpmVersion; }
+
+    public void setTpmVersion(String tpmVersion) { this.tpmVersion = tpmVersion; }
 
     public void setPoolType(String poolType) { this.poolType = poolType; }
 

--- a/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/agent/manager/AgentManagerImpl.java
@@ -613,6 +613,16 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
                         _hostDao.saveDetails(host);
                     }
                 }
+
+                String tpmEnabled = detailsMap.get(Host.HOST_TPM_ENABLE);
+                s_logger.debug(String.format("Got HOST_TPM_ENABLE [%s] for hostId [%s]:", tpmEnabled, host.getUuid()));
+                if (tpmEnabled != null) {
+                    _hostDao.loadDetails(host);
+                    if (!tpmEnabled.equals(host.getDetails().get(Host.HOST_TPM_ENABLE))) {
+                        host.getDetails().put(Host.HOST_TPM_ENABLE, tpmEnabled);
+                        _hostDao.saveDetails(host);
+                    }
+                }
             }
         }
 

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -1395,6 +1395,10 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             msgBuf.append(String.format("Boot into Setup: %s ", params.get(VirtualMachineProfile.Param.BootIntoSetup)));
             log = true;
         }
+        if (params.get(VirtualMachineProfile.Param.TpmFlag) != null) {
+            msgBuf.append(String.format("TpmFlag: %s ", params.get(VirtualMachineProfile.Param.TpmFlag)));
+            log = true;
+        }
         if (log) {
             s_logger.info(msgBuf.toString());
         }

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -1395,8 +1395,8 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             msgBuf.append(String.format("Boot into Setup: %s ", params.get(VirtualMachineProfile.Param.BootIntoSetup)));
             log = true;
         }
-        if (params.get(VirtualMachineProfile.Param.TpmFlag) != null) {
-            msgBuf.append(String.format("TpmFlag: %s ", params.get(VirtualMachineProfile.Param.TpmFlag)));
+        if (params.get(VirtualMachineProfile.Param.TpmVersion) != null) {
+            msgBuf.append(String.format("TpmVersion: %s ", params.get(VirtualMachineProfile.Param.TpmVersion)));
             log = true;
         }
         if (log) {

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
@@ -158,6 +158,13 @@ public class VMEntityManagerImpl implements VMEntityManager {
             vmProfile.getParameters().put(VirtualMachineProfile.Param.BootMode, details.get(VirtualMachineProfile.Param.BootMode.getName()));
             vmProfile.getParameters().put(VirtualMachineProfile.Param.UefiFlag, details.get(VirtualMachineProfile.Param.UefiFlag.getName()));
         }
+        if (MapUtils.isNotEmpty(vmEntityVO.getDetails()) &&
+                vmEntityVO.getDetails().containsKey(VirtualMachineProfile.Param.TpmFlag.getName()) &&
+                "Enabled".equalsIgnoreCase(vmEntityVO.getDetails().get(VirtualMachineProfile.Param.TpmFlag.getName())))
+        {
+            Map<String, String> details = vmEntityVO.getDetails();
+            vmProfile.getParameters().put(VirtualMachineProfile.Param.TpmFlag, details.get(VirtualMachineProfile.Param.UefiFlag.getName()));
+        }
         DataCenterDeployment plan = new DataCenterDeployment(vm.getDataCenterId(), vm.getPodIdToDeployIn(), null, null, null, null);
         if (planToDeploy != null && planToDeploy.getDataCenterId() != 0) {
             plan =

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
@@ -161,8 +161,7 @@ public class VMEntityManagerImpl implements VMEntityManager {
         if (MapUtils.isNotEmpty(vmEntityVO.getDetails()) &&
                 vmEntityVO.getDetails().containsKey(VirtualMachineProfile.Param.TpmVersion.getName()) &&
                 (
-                        "V2_0".equalsIgnoreCase(vmEntityVO.getDetails().get(VirtualMachineProfile.Param.TpmVersion.getName())) ||
-                        "V1_2".equalsIgnoreCase(vmEntityVO.getDetails().get(VirtualMachineProfile.Param.TpmVersion.getName()))
+                        "V2_0".equalsIgnoreCase(vmEntityVO.getDetails().get(VirtualMachineProfile.Param.TpmVersion.getName()))
                 ) )
         {
             Map<String, String> details = vmEntityVO.getDetails();

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
@@ -159,14 +159,14 @@ public class VMEntityManagerImpl implements VMEntityManager {
             vmProfile.getParameters().put(VirtualMachineProfile.Param.UefiFlag, details.get(VirtualMachineProfile.Param.UefiFlag.getName()));
         }
         if (MapUtils.isNotEmpty(vmEntityVO.getDetails()) &&
-                vmEntityVO.getDetails().containsKey(VirtualMachineProfile.Param.TpmFlag.getName()) &&
+                vmEntityVO.getDetails().containsKey(VirtualMachineProfile.Param.TpmVersion.getName()) &&
                 (
-                        "V2_0".equalsIgnoreCase(vmEntityVO.getDetails().get(VirtualMachineProfile.Param.TpmFlag.getName())) ||
-                        "V1_2".equalsIgnoreCase(vmEntityVO.getDetails().get(VirtualMachineProfile.Param.TpmFlag.getName()))
+                        "V2_0".equalsIgnoreCase(vmEntityVO.getDetails().get(VirtualMachineProfile.Param.TpmVersion.getName())) ||
+                        "V1_2".equalsIgnoreCase(vmEntityVO.getDetails().get(VirtualMachineProfile.Param.TpmVersion.getName()))
                 ) )
         {
             Map<String, String> details = vmEntityVO.getDetails();
-            vmProfile.getParameters().put(VirtualMachineProfile.Param.TpmFlag, details.get(VirtualMachineProfile.Param.TpmFlag.getName()));
+            vmProfile.getParameters().put(VirtualMachineProfile.Param.TpmVersion, details.get(VirtualMachineProfile.Param.TpmVersion.getName()));
         }
         DataCenterDeployment plan = new DataCenterDeployment(vm.getDataCenterId(), vm.getPodIdToDeployIn(), null, null, null, null);
         if (planToDeploy != null && planToDeploy.getDataCenterId() != 0) {

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
@@ -160,9 +160,8 @@ public class VMEntityManagerImpl implements VMEntityManager {
         }
         if (MapUtils.isNotEmpty(vmEntityVO.getDetails()) &&
                 vmEntityVO.getDetails().containsKey(VirtualMachineProfile.Param.TpmVersion.getName()) &&
-                (
-                        "V2_0".equalsIgnoreCase(vmEntityVO.getDetails().get(VirtualMachineProfile.Param.TpmVersion.getName()))
-                ) )
+                "V2_0".equalsIgnoreCase(vmEntityVO.getDetails().get(VirtualMachineProfile.Param.TpmVersion.getName()))
+            )
         {
             Map<String, String> details = vmEntityVO.getDetails();
             vmProfile.getParameters().put(VirtualMachineProfile.Param.TpmVersion, details.get(VirtualMachineProfile.Param.TpmVersion.getName()));

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
@@ -160,10 +160,13 @@ public class VMEntityManagerImpl implements VMEntityManager {
         }
         if (MapUtils.isNotEmpty(vmEntityVO.getDetails()) &&
                 vmEntityVO.getDetails().containsKey(VirtualMachineProfile.Param.TpmFlag.getName()) &&
-                "Enabled".equalsIgnoreCase(vmEntityVO.getDetails().get(VirtualMachineProfile.Param.TpmFlag.getName())))
+                (
+                        "V2_0".equalsIgnoreCase(vmEntityVO.getDetails().get(VirtualMachineProfile.Param.TpmFlag.getName())) ||
+                        "V1_2".equalsIgnoreCase(vmEntityVO.getDetails().get(VirtualMachineProfile.Param.TpmFlag.getName()))
+                ) )
         {
             Map<String, String> details = vmEntityVO.getDetails();
-            vmProfile.getParameters().put(VirtualMachineProfile.Param.TpmFlag, details.get(VirtualMachineProfile.Param.UefiFlag.getName()));
+            vmProfile.getParameters().put(VirtualMachineProfile.Param.TpmFlag, details.get(VirtualMachineProfile.Param.TpmFlag.getName()));
         }
         DataCenterDeployment plan = new DataCenterDeployment(vm.getDataCenterId(), vm.getPodIdToDeployIn(), null, null, null, null);
         if (planToDeploy != null && planToDeploy.getDataCenterId() != 0) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2546,6 +2546,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             tpmVersion = GuestDef.TpmVersion.NONE.toString();
             isTpmEnabled = false;
         }
+        if (tpmVersion=="NONE"){
+            isTpmEnabled = false;
+        }
         s_logger.debug("tpmEnabled: " + isTpmEnabled + " tpmVersion: " + tpmVersion);
         vm.addComp(createDevicesDef(vmTO, guest, vcpus, isUefiEnabled, isTpmEnabled, tpmVersion));
         addExtraConfigsToVM(vmTO, vm, extraConfig);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2558,7 +2558,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     /**
      * Adds devices components to VM.
      */
-    protected DevicesDef createDevicesDef(VirtualMachineTO vmTO, GuestDef guest, int vcpus, boolean isUefiEnabled, boolean isTpmEnabled, String TpmVersion) {
+    protected DevicesDef createDevicesDef(VirtualMachineTO vmTO, GuestDef guest, int vcpus, boolean isUefiEnabled, boolean isTpmEnabled, String tpmVersion) {
         DevicesDef devices = new DevicesDef();
         devices.setEmulatorPath(_hypervisorPath);
         devices.setGuestType(guest.getGuestType());
@@ -2580,7 +2580,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         }
         if (isTpmEnabled)
         {
-            devices.addDevice(createTpmDef(vmTO, guest, TpmVersion));
+            devices.addDevice(createTpmDef(vmTO, guest, tpmVersion));
         }
         DiskDef.DiskBus busT = getDiskModelFromVMDetail(vmTO);
         if (busT == null) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2572,7 +2572,10 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         if (isGuestAarch64()) {
             createArm64UsbDef(devices);
         }
-
+        if (isTpmEnabled)
+        {
+            devices.addDevice(createTpmDef(vmTO, guest, isTpmEnabled));
+        }
         DiskDef.DiskBus busT = getDiskModelFromVMDetail(vmTO);
         if (busT == null) {
             busT = getGuestDiskModel(vmTO.getPlatformEmulator(), isUefiEnabled);
@@ -2581,6 +2584,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         if (busT == DiskDef.DiskBus.SCSI) {
             devices.addDevice(createSCSIDef(vcpus));
         }
+
+
         return devices;
     }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2481,7 +2481,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
         if (MapUtils.isNotEmpty(customParams) && (
                 customParams.containsKey(GuestDef.TpmVersion.V2_0.toString()) ||
-                        customParams.containsKey(GuestDef.TpmVersion.V1_2.toString())
+                customParams.containsKey(GuestDef.TpmVersion.V1_2.toString())
         )) {
             isTpmEnabled = true;
             s_logger.debug(String.format("Enabled TPM for VM UUID [%s].", uuid));

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2595,7 +2595,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         if (isGuestAarch64()) {
             createArm64UsbDef(devices);
         }
-        if (isTpmEnabled) {
+        if (!tpmVersion.equalsIgnoreCase("NONE") && isTpmEnabled) {
             s_logger.debug("LibvirtComputingResource 2597 ycyun:" + isTpmEnabled + ": " + tpmVersion);
             devices.addDevice(createTpmDef(tpmVersion));
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2539,11 +2539,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         customParams.forEach((strKey, strValue)->{
             s_logger.debug( "ycyun: " + strKey + " : " + strValue );
         });
-        if(customParams.containsKey(GuestDef.TpmVersion.V2_0.toString())) {
-            tpmVersion = customParams.get(GuestDef.TpmVersion.V2_0.toString());
-            isTpmEnabled = true;
-        }else if(customParams.containsKey(GuestDef.TpmVersion.V1_2.toString())) {
-            tpmVersion = customParams.get(GuestDef.TpmVersion.V1_2.toString());
+        if(customParams.containsKey("tpmVersion")) {
+            tpmVersion = customParams.get("tpmVersion");
             isTpmEnabled = true;
         }else{
             tpmVersion = GuestDef.TpmVersion.NONE.toString();

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2479,9 +2479,6 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
             bootMode = customParams.get(GuestDef.BootType.UEFI.toString());
         }
-        customParams.forEach((strKey, strValue)->{
-            s_logger.debug("create vm from spec ycyun: " + strKey + " : " + strValue );
-        });
         if (MapUtils.isNotEmpty(customParams) && (
                 customParams.containsKey(GuestDef.TpmVersion.V2_0.toString()) ||
                 customParams.containsKey(GuestDef.TpmVersion.V1_2.toString())
@@ -2536,9 +2533,6 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
 
         boolean isTpmEnabled = false;
-        customParams.forEach((strKey, strValue)->{
-            s_logger.debug( "ycyun: " + strKey + " : " + strValue );
-        });
         if(customParams.containsKey("tpmVersion")) {
             tpmVersion = customParams.get("tpmVersion");
 
@@ -2551,7 +2545,6 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             tpmVersion = GuestDef.TpmVersion.NONE.toString();
             isTpmEnabled = false;
         }
-        s_logger.debug("tpmEnabled: " + isTpmEnabled + " tpmVersion: " + tpmVersion);
         vm.addComp(createDevicesDef(vmTO, guest, vcpus, isUefiEnabled, isTpmEnabled, tpmVersion));
         addExtraConfigsToVM(vmTO, vm, extraConfig);
     }
@@ -2596,7 +2589,6 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             createArm64UsbDef(devices);
         }
         if (!tpmVersion.equalsIgnoreCase("NONE") && isTpmEnabled) {
-            s_logger.debug("LibvirtComputingResource 2597 ycyun:" + isTpmEnabled + ": " + tpmVersion);
             devices.addDevice(createTpmDef(tpmVersion));
         }
         DiskDef.DiskBus busT = getDiskModelFromVMDetail(vmTO);
@@ -2781,7 +2773,6 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             }
         }
         customParams.forEach((strKey, strValue)->{
-            s_logger.debug( "[LibvirtComputingResource 2780] customParams ycyun: " + strKey + " : " + strValue );
         });
         if (MapUtils.isNotEmpty(customParams)) {
             if(customParams.containsKey(GuestDef.TpmVersion.V1_2.toString())){

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3495,7 +3495,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         cmd.setCluster(_clusterId);
         cmd.setGatewayIpAddress(_localGateway);
         cmd.setIqn(getIqn());
-        if (cmd.getHostDetails().containsKey("guest.cpu.mode")){
+        if (!cmd.getHostDetails().containsKey("guest.cpu.mode")){
             cmd.getHostDetails().put("guest.cpu.mode","host-passthrough");
         }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2480,16 +2480,16 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         }
 
         if (MapUtils.isNotEmpty(customParams) && (
-                customParams.containsKey(GuestDef.TpmEnabled.V2_0.toString()) ||
-                        customParams.containsKey(GuestDef.TpmEnabled.V1_2.toString())
+                customParams.containsKey(GuestDef.TpmVersion.V2_0.toString()) ||
+                        customParams.containsKey(GuestDef.TpmVersion.V1_2.toString())
         )) {
             isTpmEnabled = true;
             s_logger.debug(String.format("Enabled TPM for VM UUID [%s].", uuid));
 
-            if(customParams.containsKey(GuestDef.TpmEnabled.V2_0.toString())) {
-                tpmVersion = customParams.get(GuestDef.TpmEnabled.V2_0.toString());
-            }else if(customParams.containsKey(GuestDef.TpmEnabled.V1_2.toString())) {
-                tpmVersion = customParams.get(GuestDef.TpmEnabled.V1_2.toString());
+            if(customParams.containsKey(GuestDef.TpmVersion.V2_0.toString())) {
+                tpmVersion = customParams.get(GuestDef.TpmVersion.V2_0.toString());
+            }else if(customParams.containsKey(GuestDef.TpmVersion.V1_2.toString())) {
+                tpmVersion = customParams.get(GuestDef.TpmVersion.V1_2.toString());
             }
         }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2545,7 +2545,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         DevicesDef devices = new DevicesDef();
         devices.setEmulatorPath(_hypervisorPath);
         devices.setGuestType(guest.getGuestType());
-        devices.addDevice(createSerialDef());
+        devices.addDevice(new LibvirtVMDef.TPMDef());
 
         return devices;
     }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2535,18 +2535,20 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         vm.addComp(createClockDef(vmTO));
 
 
-        boolean isTpmEnabled;
+        boolean isTpmEnabled = false;
         customParams.forEach((strKey, strValue)->{
             s_logger.debug( "ycyun: " + strKey + " : " + strValue );
         });
         if(customParams.containsKey("tpmVersion")) {
             tpmVersion = customParams.get("tpmVersion");
-            isTpmEnabled = true;
+
+            if (tpmVersion.equalsIgnoreCase("NONE")){
+                isTpmEnabled = false;
+            }else{
+                isTpmEnabled = true;
+            }
         }else{
             tpmVersion = GuestDef.TpmVersion.NONE.toString();
-            isTpmEnabled = false;
-        }
-        if (tpmVersion=="NONE"){
             isTpmEnabled = false;
         }
         s_logger.debug("tpmEnabled: " + isTpmEnabled + " tpmVersion: " + tpmVersion);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -45,7 +45,6 @@ import javax.naming.ConfigurationException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.storage.configdrive.ConfigDrive;
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.cloudstack.storage.to.TemplateObjectTO;

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -45,6 +45,7 @@ import javax.naming.ConfigurationException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.storage.configdrive.ConfigDrive;
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.cloudstack.storage.to.TemplateObjectTO;
@@ -2773,6 +2774,17 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             guest.setMachineType(Q35);
             if (SECURE.equalsIgnoreCase(customParams.get(GuestDef.BootType.UEFI.toString()))) {
                 guest.setBootMode(GuestDef.BootMode.SECURE);
+            }
+        }
+        customParams.forEach((strKey, strValue)->{
+            s_logger.debug( "[LibvirtComputingResource 2780] customParams ycyun: " + strKey + " : " + strValue );
+        });
+        if (MapUtils.isNotEmpty(customParams)) {
+            if(customParams.containsKey(GuestDef.TpmVersion.V1_2.toString())){
+                guest.setTPMVersion(GuestDef.TpmVersion.V1_2);
+            }else if (customParams.containsKey(GuestDef.TpmVersion.V2_0.toString())){
+
+                guest.setTPMVersion(GuestDef.TpmVersion.V2_0);
             }
         }
         guest.setUuid(uuid);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2500,14 +2500,14 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         if (dpdkSupport && (!extraConfig.containsKey(DpdkHelper.DPDK_NUMA) || !extraConfig.containsKey(DpdkHelper.DPDK_HUGE_PAGES))) {
             s_logger.info(String.format("DPDK is enabled for VM [%s], but it needs extra configurations for CPU NUMA and Huge Pages for VM deployment.", vmTO.toString()));
         }
-        configureVM(vmTO, vm, customParams, isUefiEnabled, isSecureBoot, bootMode, extraConfig, uuid);
+        configureVM(vmTO, vm, customParams, isUefiEnabled, isSecureBoot, bootMode, tpmVersion, extraConfig, uuid);
         return vm;
     }
 
     /**
      * Configures created VM from specification, adding the necessary components to VM.
      */
-    private void configureVM(VirtualMachineTO vmTO, LibvirtVMDef vm, Map<String, String> customParams, boolean isUefiEnabled, boolean isSecureBoot, String bootMode, Map<String, String> extraConfig, String uuid) {
+    private void configureVM(VirtualMachineTO vmTO, LibvirtVMDef vm, Map<String, String> customParams, boolean isUefiEnabled, boolean isSecureBoot, String bootMode, String tpmVersion, Map<String, String> extraConfig, String uuid) {
         s_logger.debug(String.format("Configuring VM with UUID [%s].", uuid));
 
         GuestDef guest = createGuestFromSpec(vmTO, vm, uuid, customParams);
@@ -2534,7 +2534,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         vm.addComp(createTermPolicy());
         vm.addComp(createClockDef(vmTO));
 
-        String tpmVersion;
+
         boolean isTpmEnabled;
         customParams.forEach((strKey, strValue)->{
             s_logger.debug( "ycyun: " + strKey + " : " + strValue );
@@ -2594,6 +2594,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             createArm64UsbDef(devices);
         }
         if (isTpmEnabled) {
+            s_logger.debug("LibvirtComputingResource 2597 ycyun:" + isTpmEnabled + ": " + tpmVersion);
             devices.addDevice(createTpmDef(tpmVersion));
         }
         DiskDef.DiskBus busT = getDiskModelFromVMDetail(vmTO);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3470,6 +3470,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         cmd.setCluster(_clusterId);
         cmd.setGatewayIpAddress(_localGateway);
         cmd.setIqn(getIqn());
+        if (cmd.getHostDetails().containsKey("guest.cpu.mode")){
+            cmd.getHostDetails().put("guest.cpu.mode","host-passthrough");
+        }
 
         if (cmd.getHostDetails().containsKey("Host.OS")) {
             _hostDistro = cmd.getHostDetails().get("Host.OS");

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2479,7 +2479,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
             bootMode = customParams.get(GuestDef.BootType.UEFI.toString());
         }
-
+        customParams.forEach((strKey, strValue)->{
+            s_logger.debug("create vm from spec ycyun: " + strKey + " : " + strValue );
+        });
         if (MapUtils.isNotEmpty(customParams) && (
                 customParams.containsKey(GuestDef.TpmVersion.V2_0.toString()) ||
                 customParams.containsKey(GuestDef.TpmVersion.V1_2.toString())

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2547,11 +2547,11 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     /**
      * Adds TPM device component to VM
      */
-    protected DevicesDef createTpmDef(VirtualMachineTO vmTO, GuestDef guest, String TpmVersion){
+    protected DevicesDef createTpmDef(VirtualMachineTO vmTO, GuestDef guest, String tpmVersion){
         DevicesDef devices = new DevicesDef();
         devices.setEmulatorPath(_hypervisorPath);
         devices.setGuestType(guest.getGuestType());
-        devices.addDevice(new LibvirtVMDef.TPMDef(TpmVersion));
+        devices.addDevice(new LibvirtVMDef.TPMDef(tpmVersion));
 
         return devices;
     }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2497,14 +2497,14 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         if (dpdkSupport && (!extraConfig.containsKey(DpdkHelper.DPDK_NUMA) || !extraConfig.containsKey(DpdkHelper.DPDK_HUGE_PAGES))) {
             s_logger.info(String.format("DPDK is enabled for VM [%s], but it needs extra configurations for CPU NUMA and Huge Pages for VM deployment.", vmTO.toString()));
         }
-        configureVM(vmTO, vm, customParams, isUefiEnabled, isSecureBoot, bootMode, tpmVersion, extraConfig, uuid);
+        configureVM(vmTO, vm, customParams, isUefiEnabled, isSecureBoot, bootMode, extraConfig, uuid);
         return vm;
     }
 
     /**
      * Configures created VM from specification, adding the necessary components to VM.
      */
-    private void configureVM(VirtualMachineTO vmTO, LibvirtVMDef vm, Map<String, String> customParams, boolean isUefiEnabled, boolean isSecureBoot, String bootMode, String tpmVersion, Map<String, String> extraConfig, String uuid) {
+    private void configureVM(VirtualMachineTO vmTO, LibvirtVMDef vm, Map<String, String> customParams, boolean isUefiEnabled, boolean isSecureBoot, String bootMode, Map<String, String> extraConfig, String uuid) {
         s_logger.debug(String.format("Configuring VM with UUID [%s].", uuid));
 
         GuestDef guest = createGuestFromSpec(vmTO, vm, uuid, customParams);
@@ -2533,6 +2533,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
 
         boolean isTpmEnabled = false;
+        String tpmVersion = "";
         if(customParams.containsKey("tpmVersion")) {
             tpmVersion = customParams.get("tpmVersion");
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -72,12 +72,12 @@ public class LibvirtVMDef {
             }
         }
 
-        enum TpmEnabled {
+        enum TpmVersion {
             V2_0("V2_0"), V1_2("V1_2"), NONE("NONE");
 
             String _type;
 
-            TpmEnabled(String type) {
+            TpmVersion(String type) {
                 _type = type;
             }
 
@@ -117,7 +117,7 @@ public class LibvirtVMDef {
         private String _nvram;
         private String _nvramTemplate;
 
-        private TpmEnabled _tpmEnabled;
+        private TpmVersion _tpmVersion;
 
         public static final String GUEST_LOADER_SECURE = "guest.loader.secure";
         public static final String GUEST_LOADER_LEGACY = "guest.loader.legacy";
@@ -180,12 +180,12 @@ public class LibvirtVMDef {
             this._bootmode = bootmode;
         }
 
-        public TpmEnabled getTPMEnabled() {
-            return this._tpmEnabled;
+        public TpmVersion getTpmVersion() {
+            return this._tpmVersion;
         }
 
-        public void setTPMEnabled(TpmEnabled tpmEnabled) {
-            this._tpmEnabled = tpmEnabled;
+        public void setTPMVersion(TpmVersion tpmVersion) {
+            this._tpmVersion = tpmVersion;
         }
 
         @Override

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -72,6 +72,21 @@ public class LibvirtVMDef {
             }
         }
 
+        enum TpmEnabled {
+            TPM("TPM"), NONE("NONE");
+
+            String _type;
+
+            TpmEnabled(String type) {
+                _type = type;
+            }
+
+            @Override
+            public String toString() {
+                return _type;
+            }
+        }
+
         enum BootMode {
             LEGACY("LEGACY"), SECURE("SECURE");
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -73,13 +73,18 @@ public class LibvirtVMDef {
         }
 
         enum TpmVersion {
-            V2_0, V1_2, NONE;
+            V2_0("V2_0"), V1_2("V1_2"), NONE("NONE");
 
+            String _version;
+
+            TpmVersion(String version){
+                _version = version;
+            }
             @Override
             public String toString() {
-                if (this.name().equals("V1_2"))
+                if (_version.equals("V1_2"))
                     return "1.2";
-                else if (this.name().equals("V2_0"))
+                else if (_version.equals("V2_0"))
                     return "2.0";
                 return "NONE";
             }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -73,7 +73,7 @@ public class LibvirtVMDef {
         }
 
         enum TpmEnabled {
-            TPM("TPM"), NONE("NONE");
+            V2_0("V2_0"), V1_2("V1_2"), NONE("NONE");
 
             String _type;
 
@@ -178,6 +178,7 @@ public class LibvirtVMDef {
             this._bootmode = bootmode;
         }
 
+        public boolean getTPMEnabled() {return TpmEnabled;}
         @Override
         public String toString() {
             if (_type == GuestType.KVM) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -1859,6 +1859,25 @@ public class LibvirtVMDef {
         }
     }
 
+    public static class TPMDef {
+        private String version = "2.0";
+
+        public TPMDef(String version) {
+            this.version = version;
+        }
+
+        public TPMDef() {
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder tpmBuilder = new StringBuilder();
+            tpmBuilder.append("<tpm model='tpm-tis'>");
+            tpmBuilder.append(String.format("<backend type='emulator' version='%s'/>\n",this.version ) );
+            tpmBuilder.append("</tpm>\n");
+            return tpmBuilder.toString();
+        }
+    }
     public static class InputDef {
         private final String _type; /* tablet, mouse */
         private final String _bus; /* ps2, usb, xen */

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -117,6 +117,8 @@ public class LibvirtVMDef {
         private String _nvram;
         private String _nvramTemplate;
 
+        private TpmEnabled _tpmEnabled;
+
         public static final String GUEST_LOADER_SECURE = "guest.loader.secure";
         public static final String GUEST_LOADER_LEGACY = "guest.loader.legacy";
         public static final String GUEST_NVRAM_PATH = "guest.nvram.path";
@@ -178,7 +180,14 @@ public class LibvirtVMDef {
             this._bootmode = bootmode;
         }
 
-        public boolean getTPMEnabled() {return TpmEnabled;}
+        public TpmEnabled getTPMEnabled() {
+            return this._tpmEnabled;
+        }
+
+        public void setTPMEnabled(TpmEnabled tpmEnabled) {
+            this._tpmEnabled = tpmEnabled;
+        }
+
         @Override
         public String toString() {
             if (_type == GuestType.KVM) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -73,17 +73,15 @@ public class LibvirtVMDef {
         }
 
         enum TpmVersion {
-            V2_0("V2_0"), V1_2("V1_2"), NONE("NONE");
-
-            String _type;
-
-            TpmVersion(String type) {
-                _type = type;
-            }
+            V2_0, V1_2, NONE;
 
             @Override
             public String toString() {
-                return _type;
+                if (this.name().equals("V1_2"))
+                    return "1.2";
+                else if (this.name().equals("V2_0"))
+                    return "2.0";
+                return "NONE";
             }
         }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtReadyCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtReadyCommandWrapper.java
@@ -45,12 +45,22 @@ public final class LibvirtReadyCommandWrapper extends CommandWrapper<ReadyComman
         if (hostSupportsUefi() && libvirtComputingResource.isUefiPropertiesFileLoaded()) {
             hostDetails.put(Host.HOST_UEFI_ENABLE, Boolean.TRUE.toString());
         }
-
+        if (hostSupportsTpm() && libvirtComputingResource.isTpmPropertiesFileLoaded()) {
+            hostDetails.put(Host.HOST_TPM_ENABLE, Boolean.TRUE.toString());
+        }
         return new ReadyAnswer(command, hostDetails);
     }
 
     private boolean hostSupportsUefi() {
         String cmd = "rpm -qa | grep -i ovmf";
+        s_logger.debug("Running command : " + cmd);
+        int result = Script.runSimpleBashScriptForExitValue(cmd);
+        s_logger.debug("Got result : " + result);
+        return result == 0;
+    }
+
+    private boolean hostSupportsTpm() {
+        String cmd = "rpm -qa | grep -i swtpm";
         s_logger.debug("Running command : " + cmd);
         int result = Script.runSimpleBashScriptForExitValue(cmd);
         s_logger.debug("Got result : " + result);

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -415,7 +415,7 @@ public class LibvirtComputingResourceTest {
         GuestDef guest = new GuestDef();
         guest.setGuestType(GuestType.KVM);
 
-        DevicesDef devicesDef = libvirtComputingResourceSpy.createDevicesDef(to, guest, to.getCpus() + 1, false, false);
+        DevicesDef devicesDef = libvirtComputingResourceSpy.createDevicesDef(to, guest, to.getCpus() + 1, false, false,"V2_0");
         verifyDevices(devicesDef, to);
     }
 
@@ -428,7 +428,7 @@ public class LibvirtComputingResourceTest {
         GuestDef guest = new GuestDef();
         guest.setGuestType(GuestType.KVM);
 
-        DevicesDef devicesDef = libvirtComputingResourceSpy.createDevicesDef(to, guest, to.getCpus() + 1, false, false);
+        DevicesDef devicesDef = libvirtComputingResourceSpy.createDevicesDef(to, guest, to.getCpus() + 1, false, false,"V2_0");
         verifyDevices(devicesDef, to);
 
         Document domainDoc = parse(devicesDef.toString());

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -415,7 +415,7 @@ public class LibvirtComputingResourceTest {
         GuestDef guest = new GuestDef();
         guest.setGuestType(GuestType.KVM);
 
-        DevicesDef devicesDef = libvirtComputingResourceSpy.createDevicesDef(to, guest, to.getCpus() + 1, false);
+        DevicesDef devicesDef = libvirtComputingResourceSpy.createDevicesDef(to, guest, to.getCpus() + 1, false, false);
         verifyDevices(devicesDef, to);
     }
 
@@ -428,7 +428,7 @@ public class LibvirtComputingResourceTest {
         GuestDef guest = new GuestDef();
         guest.setGuestType(GuestType.KVM);
 
-        DevicesDef devicesDef = libvirtComputingResourceSpy.createDevicesDef(to, guest, to.getCpus() + 1, false);
+        DevicesDef devicesDef = libvirtComputingResourceSpy.createDevicesDef(to, guest, to.getCpus() + 1, false, false);
         verifyDevices(devicesDef, to);
 
         Document domainDoc = parse(devicesDef.toString());

--- a/server/src/main/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocator.java
+++ b/server/src/main/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocator.java
@@ -124,13 +124,15 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
             if ("secure".equalsIgnoreCase(userVmDetailVO.getValue()) || "legacy".equalsIgnoreCase(userVmDetailVO.getValue())) {
                 isVMDeployedWithUefi = true;
             }
+        }
+        s_logger.info(" Guest VM is requested with Custom[UEFI] Boot Type "+ isVMDeployedWithUefi);
+        if(userVmTpmVO != null){
+
             if ("tpmVersion".equalsIgnoreCase(userVmTpmVO.getValue())){
                 isVMDeployedWithTpm = true;
             }
         }
-        s_logger.info(" Guest VM is requested with Custom[UEFI] Boot Type "+ isVMDeployedWithUefi);
-
-
+        s_logger.info(" Guest VM is requested with Custom[TPM] version "+ isVMDeployedWithTpm);
         if (type == Host.Type.Storage) {
             // FirstFitAllocator should be used for user VMs only since it won't care whether the host is capable of routing or not
             return new ArrayList<Host>();

--- a/server/src/main/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocator.java
+++ b/server/src/main/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocator.java
@@ -119,12 +119,12 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
         boolean isVMDeployedWithUefi = false;
         boolean isVMDeployedWithTpm = false;
         UserVmDetailVO userVmDetailVO = _userVmDetailsDao.findDetail(vmProfile.getId(), "UEFI");
-        UserVmDetailVO userVmTpmVO = _userVmDetailsDao.findDetail(vmProfile.getId(), "TPM");
+        UserVmDetailVO userVmTpmVO = _userVmDetailsDao.findDetail(vmProfile.getId(), "tpmVersion");
         if(userVmDetailVO != null){
             if ("secure".equalsIgnoreCase(userVmDetailVO.getValue()) || "legacy".equalsIgnoreCase(userVmDetailVO.getValue())) {
                 isVMDeployedWithUefi = true;
             }
-            if ("TPM".equalsIgnoreCase(userVmTpmVO.getValue())){
+            if ("tpmVersion".equalsIgnoreCase(userVmTpmVO.getValue())){
                 isVMDeployedWithTpm = true;
             }
         }

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -4044,7 +4044,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             options.put(VmDetailConstants.DATA_DISK_CONTROLLER, Arrays.asList("osdefault", "ide", "scsi", "virtio"));
             options.put(VmDetailConstants.VIDEO_HARDWARE, Arrays.asList("cirrus", "vga", "qxl", "virtio"));
             options.put(VmDetailConstants.VIDEO_RAM, Collections.emptyList());
-            options.put(ApiConstants.TpmEnabled.TPM.toString(), Arrays.asList(ApiConstants.TpmVersion.NONE.toString(), ApiConstants.TpmVersion.V1_2.toString(), ApiConstants.TpmVersion.V2_0.toString()));
+            options.put(ApiConstants.TpmVersion.TPM.toString(), Arrays.asList(ApiConstants.TpmVersion.NONE.toString(), ApiConstants.TpmVersion.V1_2.toString(), ApiConstants.TpmVersion.V2_0.toString()));
         }
 
         if (HypervisorType.VMware.equals(hypervisorType)) {

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -4044,7 +4044,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             options.put(VmDetailConstants.DATA_DISK_CONTROLLER, Arrays.asList("osdefault", "ide", "scsi", "virtio"));
             options.put(VmDetailConstants.VIDEO_HARDWARE, Arrays.asList("cirrus", "vga", "qxl", "virtio"));
             options.put(VmDetailConstants.VIDEO_RAM, Collections.emptyList());
-            options.put("tpmVersion", Arrays.asList(ApiConstants.TpmVersion.NONE.toString(), ApiConstants.TpmVersion.V1_2.toString(), ApiConstants.TpmVersion.V2_0.toString()));
+            options.put("tpmVersion", Arrays.asList(ApiConstants.TpmVersion.NONE.toString(), ApiConstants.TpmVersion.V2_0.toString()));
         }
 
         if (HypervisorType.VMware.equals(hypervisorType)) {

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -4044,7 +4044,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             options.put(VmDetailConstants.DATA_DISK_CONTROLLER, Arrays.asList("osdefault", "ide", "scsi", "virtio"));
             options.put(VmDetailConstants.VIDEO_HARDWARE, Arrays.asList("cirrus", "vga", "qxl", "virtio"));
             options.put(VmDetailConstants.VIDEO_RAM, Collections.emptyList());
-            options.put(ApiConstants.TpmVersion.TPM.toString(), Arrays.asList(ApiConstants.TpmVersion.NONE.toString(), ApiConstants.TpmVersion.V1_2.toString(), ApiConstants.TpmVersion.V2_0.toString()));
+            options.put("tpmVersion", Arrays.asList(ApiConstants.TpmVersion.NONE.toString(), ApiConstants.TpmVersion.V1_2.toString(), ApiConstants.TpmVersion.V2_0.toString()));
         }
 
         if (HypervisorType.VMware.equals(hypervisorType)) {

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -133,6 +133,7 @@ import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
+import org.checkerframework.checker.units.qual.A;
 import org.springframework.stereotype.Component;
 
 import com.cloud.api.query.dao.AccountJoinDao;
@@ -4044,6 +4045,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             options.put(VmDetailConstants.DATA_DISK_CONTROLLER, Arrays.asList("osdefault", "ide", "scsi", "virtio"));
             options.put(VmDetailConstants.VIDEO_HARDWARE, Arrays.asList("cirrus", "vga", "qxl", "virtio"));
             options.put(VmDetailConstants.VIDEO_RAM, Collections.emptyList());
+            options.put(ApiConstants.TpmEnabled.TPM.toString(), Arrays.asList(ApiConstants.TpmVersion.None.toString(), ApiConstants.TpmVersion.V1_2.toString(), ApiConstants.TpmVersion.V2_0.toString()));
         }
 
         if (HypervisorType.VMware.equals(hypervisorType)) {

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -133,7 +133,6 @@ import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
-import org.checkerframework.checker.units.qual.A;
 import org.springframework.stereotype.Component;
 
 import com.cloud.api.query.dao.AccountJoinDao;
@@ -4045,7 +4044,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             options.put(VmDetailConstants.DATA_DISK_CONTROLLER, Arrays.asList("osdefault", "ide", "scsi", "virtio"));
             options.put(VmDetailConstants.VIDEO_HARDWARE, Arrays.asList("cirrus", "vga", "qxl", "virtio"));
             options.put(VmDetailConstants.VIDEO_RAM, Collections.emptyList());
-            options.put(ApiConstants.TpmEnabled.TPM.toString(), Arrays.asList(ApiConstants.TpmVersion.None.toString(), ApiConstants.TpmVersion.V1_2.toString(), ApiConstants.TpmVersion.V2_0.toString()));
+            options.put(ApiConstants.TpmEnabled.TPM.toString(), Arrays.asList(ApiConstants.TpmVersion.NONE.toString(), ApiConstants.TpmVersion.V1_2.toString(), ApiConstants.TpmVersion.V2_0.toString()));
         }
 
         if (HypervisorType.VMware.equals(hypervisorType)) {

--- a/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
@@ -238,6 +238,11 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
                 } else {
                     hostResponse.setUefiCapabilty(new Boolean(false));
                 }
+                if (hostDetails.containsKey(Host.HOST_TPM_ENABLE)) {
+                    hostResponse.setTpmCapabilty(Boolean.parseBoolean((String) hostDetails.get(Host.HOST_TPM_ENABLE)));
+                } else {
+                    hostResponse.setTpmCapabilty(new Boolean(false));
+                }
             }
             if (details.contains(HostDetails.all) && host.getHypervisorType() == Hypervisor.HypervisorType.KVM) {
                 //only kvm has the requirement to return host details

--- a/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
+++ b/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
@@ -222,9 +222,6 @@ public abstract class HypervisorGuruBase extends AdapterBase implements Hypervis
         to.setBootArgs(vmProfile.getBootArgs());
 
         Map<VirtualMachineProfile.Param, Object> map = vmProfile.getParameters();
-        map.forEach((strKey, strValue)->{
-            s_logger.debug("toVirtualMachineTO[226] ycyun: " + strKey.getName() + ": " + strValue );
-        });
         if (MapUtils.isNotEmpty(map)) {
             if (map.containsKey(VirtualMachineProfile.Param.BootMode)) {
                 if (StringUtils.isNotBlank((String) map.get(VirtualMachineProfile.Param.BootMode))) {

--- a/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
+++ b/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
@@ -222,6 +222,9 @@ public abstract class HypervisorGuruBase extends AdapterBase implements Hypervis
         to.setBootArgs(vmProfile.getBootArgs());
 
         Map<VirtualMachineProfile.Param, Object> map = vmProfile.getParameters();
+        map.forEach((strKey, strValue)->{
+            s_logger.debug("toVirtualMachineTO[226] ycyun: " + strKey + " : " + strValue );
+        });
         if (MapUtils.isNotEmpty(map)) {
             if (map.containsKey(VirtualMachineProfile.Param.BootMode)) {
                 if (StringUtils.isNotBlank((String) map.get(VirtualMachineProfile.Param.BootMode))) {
@@ -232,6 +235,12 @@ public abstract class HypervisorGuruBase extends AdapterBase implements Hypervis
             if (map.containsKey(VirtualMachineProfile.Param.BootType)) {
                 if (StringUtils.isNotBlank((String) map.get(VirtualMachineProfile.Param.BootType))) {
                     to.setBootType((String) map.get(VirtualMachineProfile.Param.BootType));
+                }
+            }
+
+            if (map.containsKey(VirtualMachineProfile.Param.TpmFlag)){
+                if (StringUtils.isNotBlank((String) map.get(VirtualMachineProfile.Param.TpmFlag))) {
+                    to.setTpmVersion((String) map.get(VirtualMachineProfile.Param.TpmFlag));
                 }
             }
         }

--- a/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
+++ b/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
@@ -223,7 +223,7 @@ public abstract class HypervisorGuruBase extends AdapterBase implements Hypervis
 
         Map<VirtualMachineProfile.Param, Object> map = vmProfile.getParameters();
         map.forEach((strKey, strValue)->{
-            s_logger.debug("toVirtualMachineTO[226] ycyun: " + strKey + " : " + strValue );
+            s_logger.debug("toVirtualMachineTO[226] ycyun: " + strKey.getName() + ": " + strValue );
         });
         if (MapUtils.isNotEmpty(map)) {
             if (map.containsKey(VirtualMachineProfile.Param.BootMode)) {

--- a/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
+++ b/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
@@ -238,9 +238,9 @@ public abstract class HypervisorGuruBase extends AdapterBase implements Hypervis
                 }
             }
 
-            if (map.containsKey(VirtualMachineProfile.Param.TpmFlag)){
-                if (StringUtils.isNotBlank((String) map.get(VirtualMachineProfile.Param.TpmFlag))) {
-                    to.setTpmVersion((String) map.get(VirtualMachineProfile.Param.TpmFlag));
+            if (map.containsKey(VirtualMachineProfile.Param.TpmVersion)){
+                if (StringUtils.isNotBlank((String) map.get(VirtualMachineProfile.Param.TpmVersion))) {
+                    to.setTpmVersion((String) map.get(VirtualMachineProfile.Param.TpmVersion));
                 }
             }
         }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -4744,6 +4744,10 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         if (uefiDetail != null) {
             addVmUefiBootOptionsToParams(additionalParams, uefiDetail.getName(), uefiDetail.getValue());
         }
+        List<UserVmDetailVO> vmdetail = userVmDetailsDao.listDetails(cmd.getEntityId());
+        vmdetail.forEach((detailVO)->{
+            s_logger.debug("start vm detail ycyun: " + detailVO.toString() );
+        });
         if (cmd.getBootIntoSetup() != null) {
             additionalParams.put(VirtualMachineProfile.Param.BootIntoSetup, cmd.getBootIntoSetup());
         }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -3116,6 +3116,11 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         vmdetail.forEach((detailVO)->{
             s_logger.debug("start vm detail ycyun: " + detailVO.getName() + " : " + detailVO.getValue() );
         });
+
+        UserVmDetailVO tpmDetail = userVmDetailsDao.findDetail(cmd.getId(), ApiConstants.TPM_VERSION);
+        if (tpmDetail != null){
+            additonalParams.put(VirtualMachineProfile.Param.TpmVersion, tpmDetail.getValue());
+        }
         return startVirtualMachine(cmd.getId(), cmd.getPodId(), cmd.getClusterId(), cmd.getHostId(), additonalParams, cmd.getDeploymentPlanner()).first();
     }
 
@@ -4750,10 +4755,14 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
         List<UserVmDetailVO> vmdetail = userVmDetailsDao.listDetails(cmd.getEntityId());
         vmdetail.forEach((detailVO)->{
-            s_logger.debug("start vm detail ycyun: " + detailVO.getName() + " : " + detailVO.getValue() );
+            s_logger.debug("deploy vm detail ycyun: " + detailVO.getName() + " : " + detailVO.getValue() );
         });
         if (cmd.getBootIntoSetup() != null) {
             additionalParams.put(VirtualMachineProfile.Param.BootIntoSetup, cmd.getBootIntoSetup());
+        }
+        UserVmDetailVO tpmDetail = userVmDetailsDao.findDetail(cmd.getEntityId(), ApiConstants.TPM_VERSION);
+        if (tpmDetail != null){
+            additionalParams.put(VirtualMachineProfile.Param.TpmVersion, tpmDetail.getValue());
         }
         return startVirtualMachine(vmId, podId, clusterId, hostId, diskOfferingMap, additionalParams, cmd.getDeploymentPlanner());
     }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -3112,10 +3112,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             addVmUefiBootOptionsToParams(additonalParams, uefiDetail.getName(), uefiDetail.getValue());
         }
 
-        List<UserVmDetailVO> vmdetail = userVmDetailsDao.listDetails(cmd.getId());
-        vmdetail.forEach((detailVO)->{
-            s_logger.debug("start vm detail ycyun: " + detailVO.getName() + " : " + detailVO.getValue() );
-        });
 
         UserVmDetailVO tpmDetail = userVmDetailsDao.findDetail(cmd.getId(), ApiConstants.TPM_VERSION);
         if (tpmDetail != null){
@@ -4753,10 +4749,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         if (uefiDetail != null) {
             addVmUefiBootOptionsToParams(additionalParams, uefiDetail.getName(), uefiDetail.getValue());
         }
-        List<UserVmDetailVO> vmdetail = userVmDetailsDao.listDetails(cmd.getEntityId());
-        vmdetail.forEach((detailVO)->{
-            s_logger.debug("deploy vm detail ycyun: " + detailVO.getName() + " : " + detailVO.getValue() );
-        });
         if (cmd.getBootIntoSetup() != null) {
             additionalParams.put(VirtualMachineProfile.Param.BootIntoSetup, cmd.getBootIntoSetup());
         }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -3112,6 +3112,10 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             addVmUefiBootOptionsToParams(additonalParams, uefiDetail.getName(), uefiDetail.getValue());
         }
 
+        List<UserVmDetailVO> vmdetail = userVmDetailsDao.listDetails(cmd.getId());
+        vmdetail.forEach((detailVO)->{
+            s_logger.debug("start vm detail ycyun: " + detailVO.getName() + " : " + detailVO.getValue() );
+        });
         return startVirtualMachine(cmd.getId(), cmd.getPodId(), cmd.getClusterId(), cmd.getHostId(), additonalParams, cmd.getDeploymentPlanner()).first();
     }
 
@@ -4746,7 +4750,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
         List<UserVmDetailVO> vmdetail = userVmDetailsDao.listDetails(cmd.getEntityId());
         vmdetail.forEach((detailVO)->{
-            s_logger.debug("start vm detail ycyun: " + detailVO.toString() );
+            s_logger.debug("start vm detail ycyun: " + detailVO.getName() + " : " + detailVO.getValue() );
         });
         if (cmd.getBootIntoSetup() != null) {
             additionalParams.put(VirtualMachineProfile.Param.BootIntoSetup, cmd.getBootIntoSetup());

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -1804,6 +1804,7 @@
 "label.user": "User",
 "label.user.conflict": "Conflict",
 "label.userdata": "Userdata",
+"label.tpm": "TPM version",
 "label.userdatal2": "User data",
 "label.username": "Username",
 "label.users": "Users",

--- a/ui/public/locales/ko_KR.json
+++ b/ui/public/locales/ko_KR.json
@@ -1861,6 +1861,7 @@
 "label.user": "\uc0ac\uc6a9\uc790",
 "label.user.conflict": "\ucda9\ub3cc",
 "label.userdata": "\uc0ac\uc6a9\uc790 \ub370\uc774\ud130",
+"label.tpm": "TPM version",
 "label.userdatal2": "\uc0ac\uc6a9\uc790 \ub370\uc774\ud130",
 "label.username": "\uc0ac\uc6a9\uc790 \uc774\ub984",
 "label.users": "\uc0ac\uc6a9\uc790",

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -570,12 +570,12 @@
                     </a-form-item>
                     <a-form-item :label="$t('label.tpm')" name="tpmVersion" ref="tpmVersion">
                       <a-select
-                        v-model:value="form.tpm"
+                        v-model:value="form.tpmVersion"
                         showSearch
                         optionFilterProp="label"
                         :filterOption="filterOption">
-                        <a-select-option v-for="tpm in options.tpm" :key="tpm.id">
-                          {{ tpm.description }}
+                        <a-select-option v-for="tpmVersion in options.tpmVersion" :key="tpm.id">
+                          {{ tpmVersion.description }}
                         </a-select-option>
                       </a-select>
                     </a-form-item>
@@ -1489,7 +1489,7 @@ export default {
         ['name', 'keyboard', 'boottype', 'bootmode', 'userdata', 'tpm'].forEach(this.fillValue)
         this.form.boottype = this.defaultBootType ? this.defaultBootType : this.options.bootTypes && this.options.bootTypes.length > 0 ? this.options.bootTypes[0].id : undefined
         this.form.bootmode = this.defaultBootMode ? this.defaultBootMode : this.options.bootModes && this.options.bootModes.length > 0 ? this.options.bootModes[0].id : undefined
-        this.form.tpm = this.defaultTPM ? this.defaultTPM : this.options.tpm && this.options.tpm.length > 0 ? this.options.tpm[0].id : undefined
+        this.form.tpmVersion = this.defaultTPM ? this.defaultTPM : this.options.tpmVersion && this.options.tpmVersion.length > 0 ? this.options.tpmVersion[0].id : undefined
         this.instanceConfig = toRaw(this.form)
       })
     },
@@ -1532,7 +1532,7 @@ export default {
       this.options.bootModes = bootModes
     },
     fetchTpm () {
-      this.options.tpm = [
+      this.options.tpmVersion = [
         { id: 'NONE', description: 'disabled' },
         { id: 'V1_2', description: 'TPM v1.2' },
         { id: 'V2_0', description: 'TPM v2.0' }
@@ -1726,7 +1726,7 @@ export default {
         if (!this.template?.deployasis) {
           deployVmData.boottype = values.boottype
           deployVmData.bootmode = values.bootmode
-          deployVmData.tpm = values.tpm
+          deployVmData.tpmVersion = values.tpmVersion
         }
         deployVmData.dynamicscalingenabled = values.dynamicscalingenabled
         if (values.userdata && values.userdata.length > 0) {

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -785,7 +785,7 @@ export default {
         keyboards: [],
         bootTypes: [],
         bootModes: [],
-        tpm: [],
+        tpmVersion: [],
         dynamicScalingVmConfig: false
       },
       rowCount: {},
@@ -1486,10 +1486,10 @@ export default {
       this.fetchTpm()
       this.fetchInstaceGroups()
       nextTick().then(() => {
-        ['name', 'keyboard', 'boottype', 'bootmode', 'userdata', 'tpm'].forEach(this.fillValue)
+        ['name', 'keyboard', 'boottype', 'bootmode', 'userdata', 'tpmversion'].forEach(this.fillValue)
         this.form.boottype = this.defaultBootType ? this.defaultBootType : this.options.bootTypes && this.options.bootTypes.length > 0 ? this.options.bootTypes[0].id : undefined
         this.form.bootmode = this.defaultBootMode ? this.defaultBootMode : this.options.bootModes && this.options.bootModes.length > 0 ? this.options.bootModes[0].id : undefined
-        this.form.tpmVersion = this.defaultTPM ? this.defaultTPM : this.options.tpmVersion && this.options.tpmVersion.length > 0 ? this.options.tpmVersion[0].id : undefined
+        this.form.tpmversion = this.defaultTPM ? this.defaultTPM : this.options.tpmVersion && this.options.tpmVersion.length > 0 ? this.options.tpmVersion[0].id : undefined
         this.instanceConfig = toRaw(this.form)
       })
     },
@@ -1726,8 +1726,8 @@ export default {
         if (!this.template?.deployasis) {
           deployVmData.boottype = values.boottype
           deployVmData.bootmode = values.bootmode
-          deployVmData.tpmVersion = values.tpmVersion
         }
+        deployVmData.tpmVersion = values.tpmVersion
         deployVmData.dynamicscalingenabled = values.dynamicscalingenabled
         if (values.userdata && values.userdata.length > 0) {
           deployVmData.userdata = encodeURIComponent(btoa(this.sanitizeReverse(values.userdata)))

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -568,7 +568,7 @@
                         v-model:value="form.userdata">
                       </a-textarea>
                     </a-form-item>
-                    <a-form-item :label="$t('label.tpm')" name="tpm" ref="tpm">
+                    <a-form-item :label="$t('label.tpm')" name="tpmVersion" ref="tpmVersion">
                       <a-select
                         v-model:value="form.tpm"
                         showSearch

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -568,6 +568,17 @@
                         v-model:value="form.userdata">
                       </a-textarea>
                     </a-form-item>
+                    <a-form-item :label="$t('label.tpm')" name="tpm" ref="tpm">
+                      <a-select
+                        v-model:value="form.tpm"
+                        showSearch
+                        optionFilterProp="label"
+                        :filterOption="filterOption">
+                        <a-select-option v-for="tpm in options.tpm" :key="tpm.id">
+                          {{ tpm.description }}
+                        </a-select-option>
+                      </a-select>
+                    </a-form-item>
                     <a-form-item :label="$t('label.affinity.groups')">
                       <affinity-group-selection
                         :items="options.affinityGroups"
@@ -774,6 +785,7 @@ export default {
         keyboards: [],
         bootTypes: [],
         bootModes: [],
+        tpm: [],
         dynamicScalingVmConfig: false
       },
       rowCount: {},
@@ -797,6 +809,7 @@ export default {
       template: {},
       defaultBootType: '',
       defaultBootMode: '',
+      defaultTPM: '',
       templateConfigurations: [],
       templateNics: [],
       templateLicenses: [],
@@ -1470,11 +1483,13 @@ export default {
       }
       this.fetchBootTypes()
       this.fetchBootModes()
+      this.fetchTpm()
       this.fetchInstaceGroups()
       nextTick().then(() => {
-        ['name', 'keyboard', 'boottype', 'bootmode', 'userdata'].forEach(this.fillValue)
+        ['name', 'keyboard', 'boottype', 'bootmode', 'userdata', 'tpm'].forEach(this.fillValue)
         this.form.boottype = this.defaultBootType ? this.defaultBootType : this.options.bootTypes && this.options.bootTypes.length > 0 ? this.options.bootTypes[0].id : undefined
         this.form.bootmode = this.defaultBootMode ? this.defaultBootMode : this.options.bootModes && this.options.bootModes.length > 0 ? this.options.bootModes[0].id : undefined
+        this.form.tpm = this.defaultTPM ? this.defaultTPM : this.options.tpm && this.options.tpm.length > 0 ? this.options.tpm[0].id : undefined
         this.instanceConfig = toRaw(this.form)
       })
     },
@@ -1515,6 +1530,13 @@ export default {
         )
       }
       this.options.bootModes = bootModes
+    },
+    fetchTpm () {
+      this.options.tpm = [
+        { id: 'NONE', description: 'disabled' },
+        { id: 'V1_2', description: 'TPM v1.2' },
+        { id: 'V2_0', description: 'TPM v2.0' }
+      ]
     },
     fetchInstaceGroups () {
       this.options.instanceGroups = []
@@ -1704,6 +1726,7 @@ export default {
         if (!this.template?.deployasis) {
           deployVmData.boottype = values.boottype
           deployVmData.bootmode = values.bootmode
+          deployVmData.tpm = values.tpm
         }
         deployVmData.dynamicscalingenabled = values.dynamicscalingenabled
         if (values.userdata && values.userdata.length > 0) {

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1534,7 +1534,6 @@ export default {
     fetchTpm () {
       this.options.tpmVersion = [
         { id: 'NONE', description: 'disabled' },
-        { id: 'V1_2', description: 'TPM v1.2' },
         { id: 'V2_0', description: 'TPM v2.0' }
       ]
     },

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -574,7 +574,7 @@
                         showSearch
                         optionFilterProp="label"
                         :filterOption="filterOption">
-                        <a-select-option v-for="tpmVersion in options.tpmVersion" :key="tpm.id">
+                        <a-select-option v-for="tpmVersion in options.tpmVersion" :key="tpmVersion.id">
                           {{ tpmVersion.description }}
                         </a-select-option>
                       </a-select>


### PR DESCRIPTION
### PR 설명

windows11등의 VM을 기동하기 위한 tpm 설정 기능 추가 및 CPU호스트패스스루 설정을 기본값으로 수정


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [x] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [ ] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [ ] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [x] 주요 기능/개선
- [ ] 소규모 기능/개선



### 스크린샷


### 테스트 방법 및 결과
cloudstack-agent 설치시 /etc/cloudstack/agent/tpm.properties 파일 생성후
`host.tpm.enable=true`
내용을 기록시 tpm 사용 호스트로 등록됨
이후 vm생성시 `Advanced mode`에 TPM 버전을 2.0으로 지정해 vm생성을 하거나
vm의 `Settings`에 `tpmVersion`을 key로 하여 설정을 적용히 guest에 TPM이 활성화 됩니다.
