### PR TITLE
Ablestack cerato tpm, IO_uring, host-passthrough 기본값 설정 추가

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -807,6 +807,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         } catch (FileNotFoundException e) {
             s_logger.error("tpm properties file not found due to: " + e.getLocalizedMessage());
         }
+        params.putIfAbsent(ENABLE_IO_URING_PROPERTY, "true");
+        params.putIfAbsent("guest.cpu.mode", "host-passthrough");
+
         _storage = new JavaStorageLayer();
         _storage.configure("StorageLayer", params);
 

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -1831,7 +1831,7 @@
 "label.user": "User",
 "label.user.conflict": "Conflict",
 "label.userdata": "Userdata",
-"label.tpm": "TPM version",
+"label.tpm": "TPM enabled",
 "label.userdatal2": "User data",
 "label.username": "Username",
 "label.users": "Users",

--- a/ui/public/locales/ko_KR.json
+++ b/ui/public/locales/ko_KR.json
@@ -1828,7 +1828,7 @@
 "label.user": "\uc0ac\uc6a9\uc790",
 "label.user.conflict": "\ucda9\ub3cc",
 "label.userdata": "\uc0ac\uc6a9\uc790 \ub370\uc774\ud130",
-"label.tpm": "TPM version",
+"label.tpm": "TPM \ud65c\uc131\ud654",
 "label.userdatal2": "\uc0ac\uc6a9\uc790 \ub370\uc774\ud130",
 "label.username": "\uc0ac\uc6a9\uc790 \uc774\ub984",
 "label.users": "\uc0ac\uc6a9\uc790",

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1535,7 +1535,6 @@ export default {
     fetchTpm () {
       this.options.tpmVersion = [
         { id: 'NONE', description: 'Disabled' },
-        //{ id: 'V1_2', description: 'TPM Version 1.2' },
         { id: 'V2_0', description: 'TPM Version 2.0' }
       ]
       this.defaultTPM = 'Disabled'

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1535,10 +1535,10 @@ export default {
     fetchTpm () {
       this.options.tpmVersion = [
         { id: 'NONE', description: 'Disabled' },
-        { id: 'V1_2', description: 'TPM Version 1.2' },
+        //{ id: 'V1_2', description: 'TPM Version 1.2' },
         { id: 'V2_0', description: 'TPM Version 2.0' }
       ]
-      this.defaultTPM = 'NONE'
+      this.defaultTPM = 'Disabled'
     },
     fetchInstaceGroups () {
       this.options.instanceGroups = []

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -809,7 +809,7 @@ export default {
       template: {},
       defaultBootType: '',
       defaultBootMode: '',
-      defaultTPM: '',
+      defaultTPM: 'NONE',
       templateConfigurations: [],
       templateNics: [],
       templateLicenses: [],
@@ -1534,7 +1534,7 @@ export default {
     },
     fetchTpm () {
       this.options.tpmVersion = [
-        { id: 'NONE', description: 'Disabled' },
+        { id: 'NONE', description: 'NONE' },
         { id: 'V2_0', description: 'TPM Version 2.0' }
       ]
       this.defaultTPM = 'NONE'

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1490,7 +1490,7 @@ export default {
         ['name', 'keyboard', 'boottype', 'bootmode', 'userdata', 'tpmversion'].forEach(this.fillValue)
         this.form.boottype = this.defaultBootType ? this.defaultBootType : this.options.bootTypes && this.options.bootTypes.length > 0 ? this.options.bootTypes[0].id : undefined
         this.form.bootmode = this.defaultBootMode ? this.defaultBootMode : this.options.bootModes && this.options.bootModes.length > 0 ? this.options.bootModes[0].id : undefined
-        this.form.tpmversion = this.defaultTPM ? this.defaultTPM : this.options.tpmVersion && this.options.tpmVersion.length > 0 ? this.options.tpmVersion[0].id : undefined
+        this.form.tpmversion = this.defaultTPM ? this.defaultTPM : this.options.tpmVersion && this.options.tpmVersion.length > 0 ? this.options.tpmVersion[0].description : undefined
         this.instanceConfig = toRaw(this.form)
       })
     },

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1538,7 +1538,7 @@ export default {
         { id: 'V1_2', description: 'TPM Version 1.2' },
         { id: 'V2_0', description: 'TPM Version 2.0' }
       ]
-      this.defaultTPM = this.options.tpmVersion?.[0]?.description || undefined
+      this.defaultTPM = 'NONE'
     },
     fetchInstaceGroups () {
       this.options.instanceGroups = []

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1538,7 +1538,7 @@ export default {
         { id: 'V1_2', description: 'TPM Version 1.2' },
         { id: 'V2_0', description: 'TPM Version 2.0' }
       ]
-      this.defaultTPM = this.options.tpmVersion?.[0]?.id || undefined
+      this.defaultTPM = this.options.tpmVersion?.[0]?.description || undefined
     },
     fetchInstaceGroups () {
       this.options.instanceGroups = []

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1607,6 +1607,7 @@ export default {
           this.defaultBootType = this.template?.details?.UEFI ? 'UEFI' : ''
           this.fetchBootModes(this.defaultBootType)
           this.defaultBootMode = this.template?.details?.UEFI
+          this.defaultTPM = 'Disabled'
         }
       } else if (name === 'isoid') {
         this.templateConfigurations = []

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -544,6 +544,17 @@
                         </a-select>
                       </a-form-item>
                     </div>
+                    <a-form-item :label="$t('label.tpm')" name="tpmVersion" ref="tpmVersion">
+                      <a-select
+                        v-model:value="form.tpmVersion"
+                        showSearch
+                        optionFilterProp="label"
+                        :filterOption="filterOption">
+                        <a-select-option v-for="tpmVersion in options.tpmVersion" :key="tpmVersion.id">
+                          {{ tpmVersion.description }}
+                        </a-select-option>
+                      </a-select>
+                    </a-form-item>
                     <a-form-item
                       :label="$t('label.bootintosetup')"
                       v-if="zoneSelected && ((tabKey === 'isoid' && hypervisor === 'VMware') || (tabKey === 'templateid' && template && template.hypervisor === 'VMware'))"
@@ -567,17 +578,6 @@
                       <a-textarea
                         v-model:value="form.userdata">
                       </a-textarea>
-                    </a-form-item>
-                    <a-form-item :label="$t('label.tpm')" name="tpmVersion" ref="tpmVersion">
-                      <a-select
-                        v-model:value="form.tpmVersion"
-                        showSearch
-                        optionFilterProp="label"
-                        :filterOption="filterOption">
-                        <a-select-option v-for="tpmVersion in options.tpmVersion" :key="tpmVersion.id">
-                          {{ tpmVersion.description }}
-                        </a-select-option>
-                      </a-select>
                     </a-form-item>
                     <a-form-item :label="$t('label.affinity.groups')">
                       <affinity-group-selection
@@ -1534,8 +1534,9 @@ export default {
     },
     fetchTpm () {
       this.options.tpmVersion = [
-        { id: 'NONE', description: 'disabled' },
-        { id: 'V2_0', description: 'TPM v2.0' }
+        { id: 'NONE', description: 'Disabled' },
+        { id: 'V1_2', description: 'TPM Version 1.2' },
+        { id: 'V2_0', description: 'TPM Version 2.0' }
       ]
     },
     fetchInstaceGroups () {

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1538,6 +1538,7 @@ export default {
         { id: 'V1_2', description: 'TPM Version 1.2' },
         { id: 'V2_0', description: 'TPM Version 2.0' }
       ]
+      this.defaultTPM = this.options.tpmVersion?.[0]?.id || undefined
     },
     fetchInstaceGroups () {
       this.options.instanceGroups = []

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -1490,7 +1490,7 @@ export default {
         ['name', 'keyboard', 'boottype', 'bootmode', 'userdata', 'tpmversion'].forEach(this.fillValue)
         this.form.boottype = this.defaultBootType ? this.defaultBootType : this.options.bootTypes && this.options.bootTypes.length > 0 ? this.options.bootTypes[0].id : undefined
         this.form.bootmode = this.defaultBootMode ? this.defaultBootMode : this.options.bootModes && this.options.bootModes.length > 0 ? this.options.bootModes[0].id : undefined
-        this.form.tpmversion = this.defaultTPM ? this.defaultTPM : this.options.tpmVersion && this.options.tpmVersion.length > 0 ? this.options.tpmVersion[0].description : undefined
+        this.form.tpmversion = this.defaultTPM ? this.defaultTPM : this.options.tpmVersion && this.options.tpmVersion.length > 0 ? this.options.tpmVersion[0].id : undefined
         this.instanceConfig = toRaw(this.form)
       })
     },
@@ -1537,7 +1537,7 @@ export default {
         { id: 'NONE', description: 'Disabled' },
         { id: 'V2_0', description: 'TPM Version 2.0' }
       ]
-      this.defaultTPM = 'Disabled'
+      this.defaultTPM = 'NONE'
     },
     fetchInstaceGroups () {
       this.options.instanceGroups = []
@@ -1607,7 +1607,7 @@ export default {
           this.defaultBootType = this.template?.details?.UEFI ? 'UEFI' : ''
           this.fetchBootModes(this.defaultBootType)
           this.defaultBootMode = this.template?.details?.UEFI
-          this.defaultTPM = 'Disabled'
+          this.defaultTPM = 'NONE'
         }
       } else if (name === 'isoid') {
         this.templateConfigurations = []

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -546,7 +546,7 @@
                     </div>
                     <a-form-item :label="$t('label.tpm')" name="tpmVersion" ref="tpmVersion">
                       <a-select
-                        v-model:value="form.tpmVersion"
+                        v-model:value="form.tpmversion"
                         showSearch
                         optionFilterProp="label"
                         :filterOption="filterOption">
@@ -809,7 +809,7 @@ export default {
       template: {},
       defaultBootType: '',
       defaultBootMode: '',
-      defaultTPM: 'NONE',
+      defaultTPM: '',
       templateConfigurations: [],
       templateNics: [],
       templateLicenses: [],
@@ -1534,7 +1534,7 @@ export default {
     },
     fetchTpm () {
       this.options.tpmVersion = [
-        { id: 'NONE', description: 'NONE' },
+        { id: 'NONE', description: 'Disabled' },
         { id: 'V2_0', description: 'TPM Version 2.0' }
       ]
       this.defaultTPM = 'NONE'


### PR DESCRIPTION
### PR 설명

이 PR은 TPM 기능을 추가하고, TPM은 비활성화가 기본값으로 선택되도록 하는 커밋과 KVM 호스트등록시 IO_uring과 host-passthrough를 기본으로 적용시키는 커밋을 포함하고 있습니다.


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [ ] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [x] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [ ] 주요 기능/개선
- [x] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [ ] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [x] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷


### 테스트 방법 및 결과

가상머신(Instances)메뉴에서 가상머신 생성시 확장모드(Advanced mode)에 TPM 활성화(TPM enabled) 메뉴 추가 및 Disabled를 기본값으로 지정되있음을 확인.
Disabled시 기존과 동일하게 TPM 없이 가상머신 생성.
TPM Version 2.0의 경우 TPM을 에뮬레이팅 하여 가상머신에 추가되어 UEFI기능과 같이 적용시 윈도우 11이 설치 가능.

생성된 가상머신의 XML을 확인시 디스크의 IO_uring과 CPU의 host-passthrough 내용 확인 가능