### PR TITLE
Ablestack cerato rbd unmap 안되는 문제 수정

### DIFF
--- a/agent/bindir/libvirtqemuhook.in
+++ b/agent/bindir/libvirtqemuhook.in
@@ -165,6 +165,7 @@ def executeProgram(programName, sysArgs):
             timer.cancel()
     except (OSError, Exception) as e:
         logger.exception("Custom script: %s finished with error: \n%s" % (programName, e))
+        pass
 
 
 def terminateProgram(process, programName):
@@ -183,7 +184,8 @@ def unmapStorage():
                 executeProgram("/usr/bin/rbd", ["unmap", img])
 
         #print(domain.toxml())
-    except:
+    except Exception as e:
+        logger.exception("exception: %s\n"%( e))
         pass
 
 if __name__ == '__main__':

--- a/agent/bindir/libvirtqemuhook.in
+++ b/agent/bindir/libvirtqemuhook.in
@@ -182,7 +182,7 @@ def unmapStorage():
                 img  = disk.getAttribute("dev")
                 executeProgram("/usr/bin/rbd", ["unmap", img])
 
-        print(domain.toxml())
+        #print(domain.toxml())
     except:
         pass
 
@@ -192,7 +192,7 @@ if __name__ == '__main__':
 
     # For docs refer https://libvirt.org/hooks.html#qemu
     logger.info("Executing qemu hook with args: %s" % sys.argv)
-    logger.info("Executing qemu hook with xml: %s" % parse(sys.stdin).toxml())
+    #logger.info("Executing qemu hook with xml: %s" % parse(sys.stdin).toxml())
     action, status = sys.argv[2:4]
 
     if action not in validQemuActions:

--- a/agent/bindir/libvirtqemuhook.in
+++ b/agent/bindir/libvirtqemuhook.in
@@ -160,11 +160,11 @@ def executeProgram(programName, sysArgs):
                 logger.info('return code: %s' % str(process.returncode))
                 raise Exception(error)
             logger.info('Custom program: %s finished successfully; output: \n%s' %
-                        (scriptName, str(output)))
+                        (programName, str(output)))
         finally:
             timer.cancel()
     except (OSError, Exception) as e:
-        logger.exception("Custom script: %s finished with error: \n%s" % (scriptName, e))
+        logger.exception("Custom script: %s finished with error: \n%s" % (programName, e))
 
 
 def terminateProgram(process, programName):


### PR DESCRIPTION
### PR 설명

이 PR은 rbd unmap 이 데이터디스크에 대해 정상적으로 처리되지 않는 문제를 해결하기 위한 수정입니다.


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [x] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [ ] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [ ] 주요 기능/개선
- [x] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [x] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [ ] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [ ] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷


### 테스트 방법 및 결과
1. rbd showmapped를 watch를 통해 관측하며 데이터디스크가 있는 VM을 켰다가 껐을때 데이터디스크가 정상적으로 unmap이 되었는지 확인.
2. rbd showmapped를 watch를 통해 관측하며 데이터디스크가 있는 VM을 마이그레이션 했을때 데이터디스크가 정상적으로 unmap이 되었는지 확인.

