### PR TITLE
클러스터 동적 자원분배 글로벌설정 및 mold 재시작시 쓰레드 활성화

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/config/ListCapabilitiesCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/config/ListCapabilitiesCmd.java
@@ -72,6 +72,7 @@ public class ListCapabilitiesCmd extends BaseCmd {
         response.setHost((String)capabilities.get("host"));
         response.setResourceRequestEnabled((Boolean)capabilities.get("resourceRequestEnabled"));
         response.setBoardEnabled((Boolean)capabilities.get("boardEnabled"));
+        response.setBalancingServiceEnabled((Boolean)capabilities.get("balancingServiceEnabled"));
 
         if (capabilities.containsKey("apiLimitInterval")) {
             response.setApiLimitInterval((Integer)capabilities.get("apiLimitInterval"));

--- a/api/src/main/java/org/apache/cloudstack/api/response/CapabilitiesResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/CapabilitiesResponse.java
@@ -136,6 +136,10 @@ public class CapabilitiesResponse extends BaseResponse {
     @Param(description = "true if boardEnabled plugin is enabled, false otherwise")
     private boolean boardEnabled;
 
+    @SerializedName("balancingserviceenabled")
+    @Param(description = "true if Balancing Service plugin is enabled, false otherwise")
+    private boolean balancingServiceEnabled;
+
     public void setSecurityGroupsEnabled(boolean securityGroupsEnabled) {
         this.securityGroupsEnabled = securityGroupsEnabled;
     }
@@ -245,5 +249,9 @@ public class CapabilitiesResponse extends BaseResponse {
 
     public void setBoardEnabled(boolean boardEnabled) {
         this.boardEnabled = boardEnabled;
+    }
+
+    public void setBalancingServiceEnabled(boolean balancingServiceEnabled) {
+        this.balancingServiceEnabled = balancingServiceEnabled;
     }
 }

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -50,6 +50,7 @@ import com.cloud.storage.dao.VMTemplateDao;
 import com.cloud.user.UserData;
 import com.cloud.user.UserDataVO;
 import com.cloud.user.dao.UserDataDao;
+import com.cloud.dc.ClusterDetailsDao;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.Command;
 import com.cloud.agent.api.PatchSystemVmAnswer;
@@ -800,6 +801,7 @@ import com.cloud.vm.dao.SecondaryStorageVmDao;
 import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.UserVmDetailsDao;
 import com.cloud.vm.dao.VMInstanceDao;
+import org.apache.cloudstack.ha.HAConfigManager;
 
 import static com.cloud.configuration.ConfigurationManagerImpl.VM_USERDATA_MAX_LENGTH;
 import static com.cloud.vm.UserVmManager.MAX_USER_DATA_LENGTH_BYTES;
@@ -962,6 +964,10 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
     protected VMTemplateDao templateDao;
     @Inject
     protected AnnotationDao annotationDao;
+    @Inject
+    private ClusterDetailsDao clusterDetailsDao;
+    @Inject
+    private HAConfigManager haConfigManager;
 
     private LockControllerListener _lockControllerListener;
     private final ScheduledExecutorService _eventExecutor = Executors.newScheduledThreadPool(1, new NamedThreadFactory("EventChecker"));
@@ -4180,7 +4186,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         final String host = _configDao.getValue("host");
         final boolean resourceRequestEnabled = Boolean.parseBoolean(_configDao.getValue("cloud.resource.request.enabled"));
         final boolean boardEnabled = Boolean.parseBoolean(_configDao.getValue("cloud.board.enabled"));
-
+        final boolean balancingServiceEnabled = Boolean.parseBoolean(_configDao.getValue("cloud.balancing.service.enabled"));
 
         // check if region-wide secondary storage is used
         boolean regionSecondaryEnabled = false;
@@ -4213,6 +4219,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         capabilities.put("host", host);
         capabilities.put("resourceRequestEnabled", resourceRequestEnabled);
         capabilities.put("boardEnabled", boardEnabled);
+        capabilities.put("balancingServiceEnabled", balancingServiceEnabled);
         capabilities.put(ApiServiceConfiguration.DefaultUIPageSize.key(), ApiServiceConfiguration.DefaultUIPageSize.value());
 
         if (apiLimitEnabled) {

--- a/server/src/main/java/org/apache/cloudstack/ha/HAManager.java
+++ b/server/src/main/java/org/apache/cloudstack/ha/HAManager.java
@@ -22,8 +22,9 @@ import com.cloud.host.Host;
 import com.cloud.host.Status;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.ha.provider.HAProvider;
+import org.apache.cloudstack.framework.config.Configurable;
 
-public interface HAManager extends HAConfigManager {
+public interface HAManager extends HAConfigManager, Configurable {
 
     ConfigKey<Integer> MaxConcurrentHealthCheckOperations = new ConfigKey<>("Advanced", Integer.class,
             "ha.max.concurrent.health.check.operations",
@@ -66,7 +67,7 @@ public interface HAManager extends HAConfigManager {
             "2500",
             "The number of pending fence operations per management server. This setting determines the size of the size of the FENCE queue.", true);
 
-    ConfigKey<Integer> balancingServiceEnabled = new ConfigKey<>("Advanced", Integer.class,
+    ConfigKey<Boolean> balancingServiceEnabled = new ConfigKey<>("Advanced", Boolean.class,
             "cloud.balancing.service.enabled",
             "false",
             "Indicates whether the dynamic balancing service plugin is enabled. Management server restart required on change", false);

--- a/server/src/main/java/org/apache/cloudstack/ha/HAManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/ha/HAManagerImpl.java
@@ -628,7 +628,7 @@ public final class HAManagerImpl extends ManagerBase implements HAManager, Clust
         LOG.info("minHostId : " + minHostId + ", maxHostId : " + maxHostId);
         Map<Long, Integer> vmMemMap = new ConcurrentHashMap<Long, Integer>();
 
-        // 메모리used가 가장 큰 호스트의 vm 조회
+        // 메모리used가 가장 큰 호스트의 vm 조회(ramsize조회를 위해 user_vm_view 테이블을 사용하므로 vm type=user로 지정)
         for (final VMInstanceVO vm: vmInstanceDao.listByHostId(maxHostId)) {
             if (vm.getType().toString() == "User") {
                 LOG.info("vmID : " + vm.getId() + ", vmRamSize : " + userVM.getRamSize());

--- a/server/src/main/java/org/apache/cloudstack/ha/HAManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/ha/HAManagerImpl.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -106,12 +105,8 @@ import com.cloud.utils.fsm.StateMachine2;
 import com.google.common.base.Preconditions;
 import org.apache.cloudstack.api.ResponseGenerator;
 import com.cloud.agent.AgentManager;
-import org.apache.cloudstack.api.response.UserVmResponse;
-import org.apache.cloudstack.api.ResponseObject;
 import com.cloud.api.query.vo.UserVmJoinVO;
 import com.cloud.api.query.dao.UserVmJoinDao;
-import com.cloud.user.Account;
-import com.cloud.user.AccountService;
 
 public final class HAManagerImpl extends ManagerBase implements HAManager, ClusterManagerListener, PluggableService, Configurable, StateListener<HAConfig.HAState, HAConfig.Event, HAConfig> {
     public static final Logger LOG = Logger.getLogger(HAManagerImpl.class);
@@ -133,9 +128,6 @@ public final class HAManagerImpl extends ManagerBase implements HAManager, Clust
 
     @Inject
     protected ResourceService resourceService;
-
-    @Inject
-    protected AccountService accountService;
 
     @Inject
     private ClusterDetailsDao clusterDetailsDao;
@@ -525,8 +517,9 @@ public final class HAManagerImpl extends ManagerBase implements HAManager, Clust
 
         /* Using Runnable Interface */
         Thread.State state = thread.getState();
-        LOG.info("===========state ====> "+state);
-        if (state.equals("TERMINATED")) {
+        LOG.info("===1.cluster balancing===");
+        LOG.info("===cluster balancing thread state : " + state);
+        if (state == Thread.State.NEW) {
             thread = new Thread(new BalancingThread(cluster.getId()));
             thread.start();
         }
@@ -542,6 +535,7 @@ public final class HAManagerImpl extends ManagerBase implements HAManager, Clust
 
         @Override
         public void runInContext() {
+            // run task
             balancingCheck(clusterId);
         }
 
@@ -568,16 +562,32 @@ public final class HAManagerImpl extends ManagerBase implements HAManager, Clust
     }
 
     public void balancingCheck (long clusterId) {
+        LOG.info("===2-1.cluster balancing check===");
+        // 클러스터의 각 호스트 메모리used 조회(mold 재시작시 hostResponse 바로 못가져오는 현상으로 인해 while문 추가)
         HashMap<Long, Long> hostMemMap = new HashMap<Long, Long>();
         for (final HostVO host: hostDao.findByClusterId(clusterId)) {
-            HostResponse hostResponse = _responseGenerator.createHostResponse(host);
-            LOG.info(hostResponse.getId());
-            LOG.info(hostResponse.getMemoryUsed()*100/hostResponse.getMemoryTotal());
+            HostResponse hostResponse = new HostResponse();
+            int retry = 5;
+            while (retry > 0) {
+                hostResponse = _responseGenerator.createHostResponse(host);
+                retry--;
+                LOG.info("retry : " + retry);
+                LOG.info("hostId : " + hostResponse.getId() + ", MemoryUsed : " + hostResponse.getMemoryUsed() + ", MemoryTotal : " + hostResponse.getMemoryTotal());
+                if (hostResponse.getMemoryUsed() != null) {
+                    break;
+                }
+                try {
+                    Thread.sleep(10000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+            LOG.info("hostID : "+hostResponse.getId() + ", hostMemPersent : "+hostResponse.getMemoryUsed()*100/hostResponse.getMemoryTotal());
 
             hostMemMap.put(host.getId(), hostResponse.getMemoryUsed()*100/hostResponse.getMemoryTotal());
         }
 
-        // Comparator
+        // 클러스터의 각 호스트 메모리used 값 비교
         Comparator<Entry<Long, Long>> comparator = new Comparator<Entry<Long, Long>>() {
             @Override
             public int compare(Entry<Long, Long> e1, Entry<Long, Long> e2) {
@@ -587,20 +597,16 @@ public final class HAManagerImpl extends ManagerBase implements HAManager, Clust
 
         // Max Value의 key, value
         Entry<Long, Long> maxEntry = Collections.max(hostMemMap.entrySet(), comparator);
-
         // Min Value의 key, value
         Entry<Long, Long> minEntry = Collections.min(hostMemMap.entrySet(), comparator);
 
-        LOG.info("start======================");
-        LOG.info("maxEntry = " + maxEntry.getValue() + ", minEntry = " + minEntry.getValue());
-        LOG.info("persent = " + (maxEntry.getValue() - minEntry.getValue()));
-        //memory 값이 10% 이상 차이나면 memory작은 호스트로 vm migration
+        LOG.info("===2-2.host max/min memoryUsed===");
+        LOG.info("maxEntry : " + maxEntry.getValue() + ", minEntry : " + minEntry.getValue() + ", persent : " + (maxEntry.getValue() - minEntry.getValue()));
+
+        //메모리used 값이 10% 이상 차이나면 메모리used가 가장 작은 호스트로 vm migration
         if ((maxEntry.getValue() - minEntry.getValue()) > 10 ) {
             String hostIp = "";
             for (final HostVO host: hostDao.findByClusterId(clusterId)) {
-                LOG.info("maxEntry.getKey() = "+maxEntry.getKey());
-                LOG.info("host.getUuid() = "+host.getUuid());
-                LOG.info("host.getId() = "+host.getId());
                 if (host.getId() == minEntry.getKey()) {
                     hostIp = host.getPrivateIpAddress();
                 }
@@ -608,48 +614,46 @@ public final class HAManagerImpl extends ManagerBase implements HAManager, Clust
             balancingMonitor(minEntry.getKey(), maxEntry.getKey());
         }
 
-        //1분 체크
+        // 1분마다 체크
         try {
             Thread.sleep(60000);
             balancingCheck(clusterId);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
-
     }
 
     private void balancingMonitor(Long minHostId, Long maxHostId) {
+        LOG.info("===3.cluster balancing monitor===");
+        LOG.info("minHostId : " + minHostId + ", maxHostId : " + maxHostId);
         Map<Long, Integer> vmMemMap = new ConcurrentHashMap<Long, Integer>();
 
+        // 메모리used가 가장 큰 호스트의 vm 조회
         for (final VMInstanceVO vm: vmInstanceDao.listByHostId(maxHostId)) {
-            LOG.info("hostId = "+maxHostId);
-            try {
-                LOG.info("vm.getId() = "+vm.getId());
-                Hashtable<Long, UserVmResponse> vmDataList = new Hashtable<Long, UserVmResponse>();
-                String responseName = "virtualmachine";
-                List<UserVmJoinVO> userVmJoinVOs = userVmJoinDao.searchByIds(vm.getId());
-                ResponseObject.ResponseView respView = ResponseObject.ResponseView.Restricted;
-                Account caller = CallContext.current().getCallingAccount();
-                if (accountService.isRootAdmin(caller.getId())) {
-                    respView = ResponseObject.ResponseView.Full;
-                }
-                LOG.info("respView = "+respView);
+            if (vm.getType().toString() == "User") {
+                LOG.info("vmID : " + vm.getId() + ", vmRamSize : " + userVM.getRamSize());
                 UserVmJoinVO userVM = userVmJoinDao.findById(vm.getId());
-                LOG.info("userVM = "+userVM.getId());
-                LOG.info("ramSize = "+userVM.getRamSize());
-                /*UserVmResponse cvmResponse = ApiDBUtils.newUserVmResponse(respView, responseName, userVM, EnumSet.of(ApiConstants.VMDetails.nics), caller);
-
-                LOG.info("cvmResponse = "+cvmResponse);
-                // userVmData = ApiDBUtils.fillVmDetails(ResponseView.Full, userVmData, userVmJoinVOs.get(0));
-                LOG.info("cvmResponse.getMemory() = "+cvmResponse.getMemory());
-                LOG.info("cvmResponse.getMemory() = "+cvmResponse.getId());*/
                 vmMemMap.put(vm.getId(), userVM.getRamSize());
-
-            } catch (Exception e) {
+            } else {
+                LOG.info("===The virtual machine to migrate does not exist.===");
             }
+            /*Hashtable<Long, UserVmResponse> vmDataList = new Hashtable<Long, UserVmResponse>();
+            String responseName = "virtualmachine";
+            List<UserVmJoinVO> userVmJoinVOs = userVmJoinDao.searchByIds(vm.getId());
+            ResponseObject.ResponseView respView = ResponseObject.ResponseView.Restricted;
+            Account caller = CallContext.current().getCallingAccount();
+            if (accountService.isRootAdmin(caller.getId())) {
+                respView = ResponseObject.ResponseView.Full;
+            }
+            UserVmResponse cvmResponse = ApiDBUtils.newUserVmResponse(respView, responseName, userVM, EnumSet.of(ApiConstants.VMDetails.nics), caller);
+
+            LOG.info("cvmResponse = "+cvmResponse);
+            // userVmData = ApiDBUtils.fillVmDetails(ResponseView.Full, userVmData, userVmJoinVOs.get(0));
+            LOG.info("cvmResponse.getMemory() = "+cvmResponse.getMemory());
+            LOG.info("cvmResponse.getMemory() = "+cvmResponse.getId());*/
         }
 
-        // Comparator
+        // vm의 ramsize 비교
         Comparator<Entry<Long, Integer>> comparator = new Comparator<Entry<Long, Integer>>() {
             @Override
             public int compare(Entry<Long, Integer> e1, Entry<Long, Integer> e2) {
@@ -660,13 +664,11 @@ public final class HAManagerImpl extends ManagerBase implements HAManager, Clust
         // Min Value의 key, value
         Entry<Long, Integer> minEntry = Collections.min(vmMemMap.entrySet(), comparator);
 
-        LOG.info("vm minEntry = "+minEntry.getKey());
-
-        //vm migration
+        //가장 작은 ramsize의 vm을 가장 작은 메모리used의 호스트로 migration
         try {
+            LOG.info("===4.vm migration===");
             Host destinationHost = resourceService.getHost(minHostId);
-            LOG.info("minEntry.getKey() = "+minEntry.getKey());
-            LOG.info("destinationHost = "+destinationHost);
+            LOG.info("minEntry.getKey() : " + minEntry.getKey() + ", destinationHost : " + destinationHost);
             userVmService.migrateVirtualMachine(minEntry.getKey(), destinationHost);
         } catch (ResourceUnavailableException ex) {
             LOG.warn("Exception: ", ex);

--- a/ui/src/config/section/infra/clusters.js
+++ b/ui/src/config/section/infra/clusters.js
@@ -191,8 +191,8 @@ export default {
       label: 'label.action.enableBalancing.cluster',
       message: 'message.action.enableBalancing.cluster',
       dataView: true,
-      show: (record) => {
-        return !record?.resourcedetails?.resourceBalancingEnabled || record?.resourcedetails?.resourceBalancingEnabled === 'false'
+      show: (record, store) => {
+        return store.features.balancingserviceenabled && (!record?.resourcedetails?.resourceBalancingEnabled || record?.resourcedetails?.resourceBalancingEnabled === 'false')
       },
       args: ['clusterid'],
       mapping: {
@@ -207,8 +207,8 @@ export default {
       label: 'label.action.disableBalancing.cluster',
       message: 'message.action.disableBalancing.cluster',
       dataView: true,
-      show: (record) => {
-        return record?.resourcedetails?.resourceBalancingEnabled && !(record?.resourcedetails?.resourceBalancingEnabled === 'false')
+      show: (record, store) => {
+        return store.features.balancingserviceenabled && (record?.resourcedetails?.resourceBalancingEnabled && !(record?.resourcedetails?.resourceBalancingEnabled === 'false'))
       },
       args: ['clusterid'],
       mapping: {


### PR DESCRIPTION
### PR 설명

1. 글로벌설정 'cloud.balancing.service.enabled' 값 활성/비활성화를 통해
클러스터 메뉴의 '클러스터 동적 자원분배 활성/비활성화' 버튼 표시.

2. mold 재시작시 클러스터 동적자원분배 활성화 쓰레드가 종료되는 문제
mold 재시작시,
글로벌설정 'cloud.balancing.service.enabled == true' && 'cluster_details.resourceBalancingEnabled == true' 면
cluster balancing 쓰레드 실행
 
<!--- 변경 사항에 대해 자세하게 설명하십시오. 그리고 변경사항을 어떻게 실행하는지도 설명합니다. -->

<!-- 새로운 기능에 대한 PR인 경우, 타당성 조사(FS) 및 디자인 컨셉(DS) 등에 대한 위키 또는 문서 등을 링크합니다. -->
<!-- 버그 수정에 대한 PR인 경우, 재현을 위한 과정과 기대 실행 및 실제 실행 결과에 대한 내용을 설명합니다. -->

<!-- "Fixes #<id>"를 사용하면 해당 이슈 및 PR이 관련 이슈/PR로 등록되어 PR이 Merge 될 때 자동으로 종료됩니다. -->
<!-- 여려 개의 이슈 또는 PR을 지정하고자 하는 경우, 여러 개의 "Fixes #<id>"를 작성합니다. -->
<!-- Fixes # -->


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [ ] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [x] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [ ] 주요 기능/개선
- [ ] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [ ] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [x] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->


