### PR TITLE
Mold 대시보드에서 기본 스토리지 전체 용량 계산 방식 변경

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import com.cloud.utils.Pair;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.utils.cryptsetup.KeyFile;
 import org.apache.cloudstack.utils.qemu.QemuImg;
@@ -78,6 +79,13 @@ import com.cloud.storage.Storage.StoragePoolType;
 import com.cloud.storage.StorageLayer;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.script.Script;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParser;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 
 public class LibvirtStorageAdaptor implements StorageAdaptor {
     protected Logger logger = LogManager.getLogger(getClass());
@@ -677,10 +685,17 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
                 logger.info("Asking libvirt to refresh storage pool " + uuid);
                 pool.refresh();
             }
-            pool.setCapacity(storage.getInfo().capacity);
-            pool.setUsed(storage.getInfo().allocation);
-            updateLocalPoolIops(pool);
-            pool.setAvailable(storage.getInfo().available);
+            if (pool.getType() == StoragePoolType.RBD) {
+                // queryCephStats 메서드 호출 (직접 Ceph에서 정확한 수치 조회)
+                Pair<Long, Long> cephStats = queryCephStats("rbd");
+                pool.setCapacity(cephStats.first());
+                pool.setUsed(cephStats.second());
+                pool.setAvailable(cephStats.first() - cephStats.second());
+            } else {
+                pool.setCapacity(storage.getInfo().capacity);
+                pool.setUsed(storage.getInfo().allocation);
+                pool.setAvailable(storage.getInfo().available);
+            }
 
             logger.debug("Successfully refreshed pool " + uuid +
                            " Capacity: " + toHumanReadableSize(storage.getInfo().capacity) +
@@ -691,6 +706,59 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
         } catch (LibvirtException e) {
             logger.debug("Could not find storage pool " + uuid + " in libvirt");
             throw new CloudRuntimeException(e.toString(), e);
+        }
+    }
+
+    /**
+     * Ceph 풀의 저장량과 총 논리 용량을 계산하여 반환합니다.
+     * Returns the logical used and total capacity for a given Ceph pool.
+     * - 사용량은 stored 값을 기반으로 하며 (복제 미포함)
+     * - 총 용량은 stored + (max_avail / replicationFactor) 방식으로 계산합니다.
+     *
+     * @param poolName Ceph 풀 이름 / Name of the Ceph pool (e.g., "rbd")
+     * @return (총 용량, 사용량) / (total capacity, used capacity) in bytes
+     */
+    public static Pair<Long, Long> queryCephStats(String poolName) {
+        try {
+            Process process = new ProcessBuilder("ceph", "df", "--format=json").start();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            StringBuilder output = new StringBuilder();
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                output.append(line);
+            }
+            process.waitFor();
+
+            JsonParser parser = new JsonParser();
+            JsonObject root = parser.parse(output.toString()).getAsJsonObject();
+            JsonArray pools = root.getAsJsonArray("pools");
+
+            long stored = 0;
+            long maxAvail = 0;
+
+            for (JsonElement el : pools) {
+                JsonObject pool = el.getAsJsonObject();
+                String name = pool.get("name").getAsString();
+
+                if (!name.equals(poolName)) {
+                    continue;
+                }
+
+                JsonObject stats = pool.getAsJsonObject("stats");
+                stored = stats.get("stored").getAsLong();
+                maxAvail = stats.get("max_avail").getAsLong();
+                break;
+            }
+
+            long logicalMaxAvail = maxAvail;
+            long total = stored + logicalMaxAvail;
+            long used = stored;
+
+            return new Pair<>(total, used);
+
+        } catch (Exception e) {
+            throw new CloudRuntimeException("Failed to execute 'ceph df --format=json': " + e.getMessage(), e);
         }
     }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -713,7 +713,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
      * Ceph 풀의 저장량과 총 논리 용량을 계산하여 반환합니다.
      * Returns the logical used and total capacity for a given Ceph pool.
      * - 사용량은 stored 값을 기반으로 하며 (복제 미포함)
-     * - 총 용량은 stored + (max_avail / replicationFactor) 방식으로 계산합니다.
+     * - 총 용량은 stored + max_avail 방식으로 계산합니다.
      *
      * @param poolName Ceph 풀 이름 / Name of the Ceph pool (e.g., "rbd")
      * @return (총 용량, 사용량) / (total capacity, used capacity) in bytes


### PR DESCRIPTION
… 정정 함

### PR 설명

Mold 대시보드에서 기본 스토리지 사용량 부분의 전체 용량을 ceph df 결과값 "MAX AVAIL + STORED" 로 정정합니다.


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [x] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [ ] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [ ] 주요 기능/개선
- [x] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [ ] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [x] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->


