### PR TITLE
Wall 접속 uri 변경(logout 제거)

### DIFF
--- a/ui/src/components/header/UserMenu.vue
+++ b/ui/src/components/header/UserMenu.vue
@@ -213,7 +213,7 @@ export default {
           wallPortalDomain = this.$store.getters.features.host
         }
         const uri = wallPortalProtocol + '://' + wallPortalDomain + ':' + wallPortalPort
-        this.uriInfo = uri + '/logout'
+        this.uriInfo = uri
         window.open(this.uriInfo, '_blank')
       })
     },


### PR DESCRIPTION
### PR 설명

Wall 접속 시 사용되는 URI에서 `logout` 파라미터를 제거하여 불필요한 로그아웃 동작을 방지했습니다.

### 변경 구분

- [x] 잠재적 기능/오류 개선

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [x] 소규모 기능/개선

#### 버그 심각도

- [x] 경미

### 테스트 방법 및 결과

Wall 접속 URI에서 logout 파라미터 제거 후 정상 접속 여부 확인
