### PR TITLE
[Mold API] HIKARI Pool DB커넥션 사용시 현재 active, idle, total, usage 값을 확인 할 수 있는 스레드 추가

### DIFF
--- a/framework/cluster/src/main/java/com/cloud/cluster/ClusterManagerImpl.java
+++ b/framework/cluster/src/main/java/com/cloud/cluster/ClusterManagerImpl.java
@@ -829,7 +829,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                 queueNotification(new ClusterManagerMessage(ClusterManagerMessage.MessageType.nodeRemoved, downHostList));
             }
         } else {
-            logger.info("No inactive management server node found");
+            logger.debug("No inactive management server node found");
         }
     }
 

--- a/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
@@ -29,6 +29,9 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import javax.sql.DataSource;
@@ -52,6 +55,7 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.mgmt.JmxUtil;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.HikariPoolMXBean;
 
 /**
  * Transaction abstracts away the Connection object in JDBC.  It allows the
@@ -87,6 +91,16 @@ public class TransactionLegacy implements Closeable {
 
     public static final short CONNECTED_DB = -1;
     public static final String CONNECTION_PARAMS = "scrollTolerantForwardOnly=true";
+    private static final java.util.concurrent.atomic.AtomicBoolean POOL_MONITOR_STARTED = new java.util.concurrent.atomic.AtomicBoolean(false);
+    private static ScheduledExecutorService poolLogger = Executors.newSingleThreadScheduledExecutor();
+
+    // Hikari DS 보관용(있다면)
+    private static com.zaxxer.hikari.HikariDataSource hikariCloudDS;
+    private static com.zaxxer.hikari.HikariDataSource hikariUsageDS;
+
+    // ---- pool 증감 표시용 간단 상태 ----
+    private static final Prev prevCloud = new Prev();
+    private static final Prev prevUsage = new Prev();
 
     private static AtomicLong s_id = new AtomicLong();
     private static final TransactionMBeanImpl s_mbean = new TransactionMBeanImpl();
@@ -1162,6 +1176,7 @@ public class TransactionLegacy implements Closeable {
             } catch (Exception e) {
                 LOGGER.debug("Simulator DB properties are not available. Not initializing simulator DS");
             }
+            startPoolMonitorOnce();
         } catch (final Exception e) {
             s_ds = getDefaultDataSource(dbProps.getProperty("db.cloud.connectionPoolLib"), "cloud");
             s_usageDS = getDefaultDataSource(dbProps.getProperty("db.usage.connectionPoolLib"), "cloud_usage");
@@ -1169,6 +1184,7 @@ public class TransactionLegacy implements Closeable {
             LOGGER.warn(
                     "Unable to load db configuration, using defaults with 5 connections. Falling back on assumed datasource on localhost:3306 using username:password=cloud:cloud. Please check your configuration",
                     e);
+            startPoolMonitorOnce();
         }
     }
 
@@ -1314,6 +1330,12 @@ public class TransactionLegacy implements Closeable {
         config.addDataSourceProperty("maintainTimeStats", "false");
 
         HikariDataSource dataSource = new HikariDataSource(config);
+        if ("cloud".equals(dsName)) {
+            hikariCloudDS = dataSource;
+        } else if ("usage".equals(dsName)) {
+            hikariUsageDS = dataSource;
+        }
+
         return dataSource;
     }
 
@@ -1439,4 +1461,93 @@ public class TransactionLegacy implements Closeable {
         }
     }
 
+    private static final class Prev {
+        int active = Integer.MIN_VALUE;
+        int idle   = Integer.MIN_VALUE;
+        int total  = Integer.MIN_VALUE;
+    }
+
+    private static String arrow(int now, int prev) {
+        if (prev == Integer.MIN_VALUE) return "→ 0"; // 첫 호출
+        int d = now - prev;
+        if (d > 0)  return "▲ +" + d;  // 증가
+        if (d < 0)  return "▼ "  + d;  // 감소
+        return "→ 0";                  // 변화 없음
+    }
+
+    private static void startPoolMonitorOnce() {
+        if (POOL_MONITOR_STARTED.compareAndSet(false, true)) {
+            startPoolMonitor(); // ← 이미 만들어둔 1분 주기 로거
+            LOGGER.info("Started HikariCP pool monitor.");
+        }
+    }
+
+    public static void startPoolMonitor() {
+        poolLogger.scheduleAtFixedRate(() -> {
+            try {
+                logPoolStats();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }, 0, 30, TimeUnit.SECONDS);
+    }
+
+    public static void logPoolStats() {
+        final String RESET = "\u001B[0m";
+        final String GRAY  = "\u001B[90m";
+        final String RED   = "\u001B[31m";
+        final String GREEN = "\u001B[32m";
+        final String BLUE  = "\u001B[34m";
+        final String YEL   = "\u001B[93m";
+
+        // helper
+        java.util.function.BiConsumer<String, HikariDataSource> logOne = (name, ds) -> {
+            if (ds == null) return;
+            HikariPoolMXBean bean = ds.getHikariPoolMXBean();
+            int act = bean.getActiveConnections();
+            int idle = bean.getIdleConnections();
+            int tot  = bean.getTotalConnections();
+            int max  = Math.max(ds.getMaximumPoolSize(), 1); // 0 보호
+
+            // Active 컬러: 80% 이상이면 RED, 아니면 GREEN
+            boolean isHigh = (act * 100 / max) >= 80;
+            String actColor = isHigh ? RED : GREEN;
+
+            // 이전값 선택
+            boolean isCloud = name.equals("HIKARI-POOL-CLOUD-DB");
+            int prevAct  = isCloud ? prevCloud.active : prevUsage.active;
+            int prevIdle = isCloud ? prevCloud.idle   : prevUsage.idle;
+            int prevTot  = isCloud ? prevCloud.total  : prevUsage.total;
+
+            // Util: act / max (%)
+            int util = act * 100 / max;
+            String utilColor = util >= 80 ? RED : (util >= 60 ? YEL : GREEN);
+
+            String msg = String.format(
+                "%s[%s]%s | %sActive=%-3d (%-5s)%s | %sIdle=%-3d (%-5s)%s | %sTotal=%-3d (%-5s)%s | %sMax=%d%s | %sUtil=%3d%%%s",
+                GRAY, name, RESET,
+                actColor, act,  arrow(act,  prevAct),  RESET,
+                BLUE,     idle, arrow(idle, prevIdle), RESET,
+                YEL,      tot,  arrow(tot,  prevTot),  RESET,
+                GRAY,     max,  RESET,
+                utilColor, util, RESET
+            );
+
+            if (isHigh) {
+                LOGGER.warn(msg + " ⚠️ HIGH UTILIZATION");
+            } else {
+                LOGGER.info(msg);
+            }
+
+            // 이전값 저장
+            if (isCloud) {
+                prevCloud.active = act; prevCloud.idle = idle; prevCloud.total = tot;
+            } else {
+                prevUsage.active = act; prevUsage.idle = idle; prevUsage.total = tot;
+            }
+        };
+
+        logOne.accept("HIKARI-POOL-CLOUD-DB", hikariCloudDS);
+        logOne.accept("HIKARI-POOL-USAGE-DB", hikariUsageDS);
+    }
 }

--- a/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
@@ -1478,7 +1478,7 @@ public class TransactionLegacy implements Closeable {
     private static void startPoolMonitorOnce() {
         if (POOL_MONITOR_STARTED.compareAndSet(false, true)) {
             startPoolMonitor(); // ← 이미 만들어둔 1분 주기 로거
-            LOGGER.info("Started HikariCP pool monitor.");
+            LOGGER.debug("Started HikariCP pool monitor.");
         }
     }
 
@@ -1536,7 +1536,7 @@ public class TransactionLegacy implements Closeable {
             if (isHigh) {
                 LOGGER.warn(msg + " ⚠️ HIGH UTILIZATION");
             } else {
-                LOGGER.info(msg);
+                LOGGER.debug(msg);
             }
 
             // 이전값 저장


### PR DESCRIPTION
### PR 설명

[Mold API] HIKARI Pool DB커넥션 사용시 현재 active, idle, total, usage 값을 확인 할 수 있는 스레드 추가(30초 간격)
- maxActive 기준 현재 active 이용률 확인 및 80% 이상 일때 로그레벨을 debug > warn 레벨로 표시 

<!--- 변경 사항에 대해 자세하게 설명하십시오. 그리고 변경사항을 어떻게 실행하는지도 설명합니다. -->

<!-- 새로운 기능에 대한 PR인 경우, 타당성 조사(FS) 및 디자인 컨셉(DS) 등에 대한 위키 또는 문서 등을 링크합니다. -->
<!-- 버그 수정에 대한 PR인 경우, 재현을 위한 과정과 기대 실행 및 실제 실행 결과에 대한 내용을 설명합니다. -->

<!-- "Fixes #<id>"를 사용하면 해당 이슈 및 PR이 관련 이슈/PR로 등록되어 PR이 Merge 될 때 자동으로 종료됩니다. -->
<!-- 여려 개의 이슈 또는 PR을 지정하고자 하는 경우, 여러 개의 "Fixes #<id>"를 작성합니다. -->
<!-- Fixes # -->


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [x] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [ ] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [ ] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [x] 주요 기능/개선
- [ ] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [ ] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [ ] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷
<img width="1834" height="58" alt="image" src="https://github.com/user-attachments/assets/f96d70b1-c595-4852-b9dc-9a1917adfbd8" />


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->


