### PR TITLE
Mold DB 용량 임계치 초과 시, 이벤트 삭제 기능의 버그 수정 및 기능 활성/비활성 설정 추가

### DIFF
--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -845,7 +845,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
             getRuntimeData(newEntry);
             getMemoryData(newEntry);
             // newEntry must now include a pid!
-//            getProcFileSystemData(newEntry);
+            getProcFileSystemData(newEntry);
             // proc memory data has precedence over mbean memory data
             getCpuData(newEntry);
             getFileSystemData(newEntry);

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -312,6 +312,15 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
 
     protected static ConfigKey<Integer> vmDiskStatsMaxRetentionTime = new ConfigKey<>("Advanced", Integer.class, "vm.disk.stats.max.retention.time", "720",
             "The maximum time (in minutes) for keeping VM disks stats records in the database. The VM disks stats cleanup process will be disabled if this is set to 0 or less than 0.", true);
+    protected static final ConfigKey<Boolean> MANAGEMENT_DB_AUTODELETE_ENABLED_BY_THRESHOLD =
+            new ConfigKey<>(
+                    "Advanced",
+                    Boolean.class,
+                    "management.db.autodelete.enabled.by.threshold",
+                    "false",
+                    "Enable automatic deletion of oldest records in the 'event' table when DB filesystem usage exceeds threshold.",
+                    true
+            );
 
     private static StatsCollector s_instance = null;
 
@@ -836,7 +845,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
             getRuntimeData(newEntry);
             getMemoryData(newEntry);
             // newEntry must now include a pid!
-            getProcFileSystemData(newEntry);
+//            getProcFileSystemData(newEntry);
             // proc memory data has precedence over mbean memory data
             getCpuData(newEntry);
             getFileSystemData(newEntry);
@@ -1085,13 +1094,56 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
         }
 
         private void checkDBCapacityThreshold(@NotNull ManagementServerHostStatsEntry newEntry) {
-            // Check mysql server storage capacity exceeds a set threshold
-            String managementServerDatabaseStorageCapacityThreshold = (_configDao.getValue(Config.ManagementServerDatabaseStorageCapacityThreshold.key()).replace(".", ""));
+            // ON/OFF 설정 읽기
+            final boolean isAutoDeleteEnabled = Boolean.TRUE.equals(MANAGEMENT_DB_AUTODELETE_ENABLED_BY_THRESHOLD.value());
+            // 비활성화면 즉시 종료 (플래그 해제 + 로그)
+            if (!isAutoDeleteEnabled) {
+                DELETE_EVENT_ACTIVE = false;
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Auto-delete disabled (management.db.autodelete.enabled.by.threshold=false). Skipping delete.");
+                }
+                return;
+            }
+            // DB 삭제 임계치 추출
+            String rawThreshold = _configDao.getValue(Config.ManagementServerDatabaseStorageCapacityThreshold.key()).trim();
+            double th = Double.parseDouble(rawThreshold);
+            String managementServerDatabaseStorageCapacityThreshold = Integer.toString(
+                    (int) Math.round(th <= 1.0 ? th * 100.0 : th));
             int intMysqlThreshold = Integer.parseInt(managementServerDatabaseStorageCapacityThreshold);
-            // Percent free of the Filesystem mounted with that path(var: mysqlDataDir).
-            String mysqlDataDir = "/var/lib/mysql/";
-            String mysqlDuThreshold = (Script.runSimpleBashScript("df -h "+mysqlDataDir+" | awk 'NR==2 {print $5}'").replace("%", ""));
-            int intDfThreshold = Integer.parseInt(mysqlDuThreshold);
+            // mysql 경로 추출
+            String mysqlDataDir = null;
+            TransactionLegacy txn0 = TransactionLegacy.open("getDatadir");
+            try {
+                txn0.start();
+                Connection conn = txn0.getConnection();
+                try (PreparedStatement ps = conn.prepareStatement("SELECT @@datadir");
+                     ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        mysqlDataDir = rs.getString(1);
+                    }
+                }
+                txn0.commit();
+            } catch (Exception e) {
+                logger.warn("Failed to read @@datadir, fallback to /var/lib/mysql/: " + e.getMessage());
+            } finally {
+                try { if (txn0 != null) { txn0.close(); } } catch (Exception ignore) { }
+            }
+            if (mysqlDataDir == null || mysqlDataDir.isEmpty()) {
+                mysqlDataDir = "/var/lib/mysql/";
+            }
+            // mysql 경로 파티션 용량 추출
+            String cmd = "LC_ALL=C df -P \"" + mysqlDataDir + "\" | awk 'NR==2 {gsub(/%/, \"\"); print $5}'";
+            String mysqlDuThreshold = Script.runSimpleBashScript(cmd);
+            mysqlDuThreshold = mysqlDuThreshold == null ? "" : mysqlDuThreshold.trim();
+            int intDfThreshold;
+            try {
+                intDfThreshold = Integer.parseInt(mysqlDuThreshold);
+            } catch (NumberFormatException e) {
+                logger.warn("Cannot parse df percent for " + mysqlDataDir + ": '" + mysqlDuThreshold + "'. Skip this cycle.", e);
+                return;
+            }
+            intDfThreshold = Math.max(0, Math.min(100, intDfThreshold));
+            DELETE_EVENT_ACTIVE = false;
             if (intDfThreshold > intMysqlThreshold) {
                 DELETE_EVENT_ACTIVE = true;
                 // Every 720 minutes(= 12 hours)
@@ -2415,7 +2467,8 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
             vmStatsIncrementMetrics, vmStatsMaxRetentionTime, vmStatsCollectUserVMOnly, vmDiskStatsRetentionEnabled, vmDiskStatsMaxRetentionTime,
                 MANAGEMENT_SERVER_STATUS_COLLECTION_INTERVAL,
                 DATABASE_SERVER_STATUS_COLLECTION_INTERVAL,
-                DATABASE_SERVER_LOAD_HISTORY_RETENTION_NUMBER};
+                DATABASE_SERVER_LOAD_HISTORY_RETENTION_NUMBER,
+                MANAGEMENT_DB_AUTODELETE_ENABLED_BY_THRESHOLD};
     }
 
     public double getImageStoreCapacityThreshold() {


### PR DESCRIPTION
### PR 설명

- [x] Mold DB 용량 임계치 초과 시, 이벤트 삭제하는 기능에서 임계치가 초과하지 않았는데 DB 이벤트가 계속 삭제되는 버그 수정
  (원인은 코드 상 임계치 수치를 변환하는 과정에서 버그 발생되어 잘못된 수치가 적용 됨.)

- [x] 기능 활성/비활성 설정 추가


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [x] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [ ] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [ ] 주요 기능/개선
- [x] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [x] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [ ] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->


