### PR TITLE
[Mold UI] VPC 오퍼링 LB 서비스의 provider가 여러 개인 경우 출력 오류 수정

### DIFF
--- a/ui/src/components/view/DetailsTab.vue
+++ b/ui/src/components/view/DetailsTab.vue
@@ -56,7 +56,7 @@
           <br/>
           <div v-if="Array.isArray(dataResource[item]) && item === 'service'">
             <div v-for="(service, idx) in dataResource[item]" :key="idx">
-              {{ service.name }} : {{ service.provider?.[0]?.name }}
+              {{ service.name }} : {{ service.provider.map(p => p.name).join(', ') }}
             </div>
           </div>
           <div v-else-if="$route.meta.name === 'backup' && (item === 'size' || item === 'virtualsize')">

--- a/ui/src/views/network/VpcTiersTab.vue
+++ b/ui/src/views/network/VpcTiersTab.vue
@@ -619,15 +619,15 @@ export default {
         this.networkOfferings = json.listnetworkofferingsresponse.networkoffering || []
         var filteredOfferings = []
         const vpcLbServiceIndex = this.resource.service.map(svc => { return svc.name }).indexOf('Lb')
+        const vpcLbServiceProviders = vpcLbServiceIndex === -1 ? [] : ((this.resource.service[vpcLbServiceIndex].provider || []).map(p => p.name))
         for (var index in this.networkOfferings) {
           const offering = this.networkOfferings[index]
           const idx = offering.service.map(svc => { return svc.name }).indexOf('Lb')
-          if (this.publicLBExists && (idx === -1 || this.lbProviderMap.publicLb.vpc.indexOf(offering.service.map(svc => { return svc.provider[0].name })[idx]) === -1)) {
+          const offeringLbServiceProviders = idx === -1 ? [] : ((offering.service[idx].provider || []).map(p => p.name))
+          if (this.publicLBExists && (idx === -1 || !offeringLbServiceProviders.some(p => this.lbProviderMap.publicLb.vpc.indexOf(p) !== -1))) {
             filteredOfferings.push(offering)
           } else if (!this.publicLBExists && vpcLbServiceIndex > -1) {
-            const vpcLbServiceProvider = vpcLbServiceIndex === -1 ? undefined : this.resource.service[vpcLbServiceIndex].provider[0].name
-            const offeringLbServiceProvider = idx === -1 ? undefined : offering.service[idx].provider[0].name
-            if (vpcLbServiceProvider && (!offeringLbServiceProvider || (offeringLbServiceProvider && vpcLbServiceProvider === offeringLbServiceProvider))) {
+            if (vpcLbServiceProviders.length > 0 && (offeringLbServiceProviders.length === 0 || offeringLbServiceProviders.some(p => vpcLbServiceProviders.indexOf(p) !== -1))) {
               filteredOfferings.push(offering)
             }
           } else {


### PR DESCRIPTION
### PR 설명

VPC 오퍼링 상세화면의 LB 제공자와 VPC 새 서브넷 추가 시 네트워크 오퍼링 목록이 LB 제공자[0] 으로 고정되는 이슈

- [x] VPC 오퍼링 상세화면의 지원 서비스 LB 제공자 목록 출력 오류
- [x] VPC 새 서브넷 추가 시 네트워크 오퍼링 목록 출력 오류

<!--- 변경 사항에 대해 자세하게 설명하십시오. 그리고 변경사항을 어떻게 실행하는지도 설명합니다. -->

<!-- 새로운 기능에 대한 PR인 경우, 타당성 조사(FS) 및 디자인 컨셉(DS) 등에 대한 위키 또는 문서 등을 링크합니다. -->
<!-- 버그 수정에 대한 PR인 경우, 재현을 위한 과정과 기대 실행 및 실제 실행 결과에 대한 내용을 설명합니다. -->

<!-- "Fixes #<id>"를 사용하면 해당 이슈 및 PR이 관련 이슈/PR로 등록되어 PR이 Merge 될 때 자동으로 종료됩니다. -->
<!-- 여려 개의 이슈 또는 PR을 지정하고자 하는 경우, 여러 개의 "Fixes #<id>"를 작성합니다. -->
<!-- Fixes # -->


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [x] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [ ] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [x] 주요 기능/개선
- [ ] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [x] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [ ] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [ ] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷
VPC 오퍼링 상세화면의 지원 서비스 LB 제공자 목록 출력 오류 > 변경 전
<img width="1162" height="693" alt="스크린샷 2025-11-07 오전 10 39 34" src="https://github.com/user-attachments/assets/d3e91118-e109-4618-9e1f-bfc3c26c1a8a" />

 VPC 새 서브넷 추가 시 네트워크 오퍼링 목록 출력 오류 > 변경 전
<img width="534" height="579" alt="스크린샷 2025-11-07 오전 10 40 11" src="https://github.com/user-attachments/assets/d39d9c81-428d-46d2-b96c-81aa602b8531" />

### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->

VPC 오퍼링 상세화면의 지원 서비스 LB 제공자 목록 출력 오류 > 변경 후
<img width="1059" height="784" alt="스크린샷 2025-11-07 오전 10 39 48" src="https://github.com/user-attachments/assets/395a81fb-3324-47bd-ab30-647c66fe12ca" />

 VPC 새 서브넷 추가 시 네트워크 오퍼링 목록 출력 오류 > 변경 후
<img width="534" height="581" alt="스크린샷 2025-11-07 오전 10 40 24" src="https://github.com/user-attachments/assets/d04b1392-3448-4e36-a19c-87fe7ea8fd9a" />

