### PR TITLE
[Mold] 디바이스 멀티패스 할당/삭제 및 extraconfig 오류 수정

### DIFF
--- a/core/src/main/java/com/cloud/resource/ServerResourceBase.java
+++ b/core/src/main/java/com/cloud/resource/ServerResourceBase.java
@@ -51,6 +51,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -363,7 +364,8 @@ public abstract class ServerResourceBase implements ServerResource {
         for (File entry : entries) {
             String bname = entry.getName();
             if (!(bname.startsWith("sd") || bname.startsWith("vd") || bname.startsWith("xvd") ||
-                  bname.startsWith("nvme") || bname.startsWith("dm-"))) {
+                  bname.startsWith("nvme"))) {
+                // dm- 디바이스는 multipath 수집 단계에서 처리하므로 여기서는 건너뜀
                 continue;
             }
 
@@ -379,6 +381,7 @@ public abstract class ServerResourceBase implements ServerResource {
             }
         }
 
+        // multipath 디바이스 수집 (dm- 디바이스 포함)
         collectMultipathDevicesUnified(names, texts, hasPartitions, scsiAddresses, scsiAddressCache, addedDevices);
     }
 
@@ -414,72 +417,389 @@ public abstract class ServerResourceBase implements ServerResource {
             hasPartitionsList.add(deviceHasPartitions);
             scsiAddresses.add(scsiAddr != null ? scsiAddr : "");
         } else {
+            // by-id 경로가 없어도 기본 경로로 추가
+            names.add(devPath);
+            texts.add(info.toString());
+            hasPartitionsList.add(deviceHasPartitions);
+            scsiAddresses.add(scsiAddr != null ? scsiAddr : "");
         }
     }
 
     private void collectMultipathDevicesUnified(List<String> names, List<String> texts, List<Boolean> hasPartitionsList,
                                                List<String> scsiAddresses, Map<String, String> scsiAddressCache, Set<String> addedDevices) {
+        AtomicInteger multipathDevicesAdded = new AtomicInteger(0);
+        Set<String> addedMpathGroups = new HashSet<>();
         try {
-            Script cmd = new Script("/usr/sbin/multipath");
+            // multipath -ll 명령어로 상세 정보 수집 (우선 사용)
+            Script cmdLL = null;
+            String multipathPath = null;
+            String[] possiblePaths = {"/usr/sbin/multipath", "/usr/bin/multipath", "/sbin/multipath"};
+            for (String path : possiblePaths) {
+                File f = new File(path);
+                if (f.exists() && f.canExecute()) {
+                    multipathPath = path;
+                    cmdLL = new Script(path);
+                    break;
+                }
+            }
+            if (cmdLL == null) {
+                cmdLL = new Script("/usr/sbin/multipath");
+            }
+            cmdLL.add("-ll");
+            OutputInterpreter.AllLinesParser parserLL = new OutputInterpreter.AllLinesParser();
+            String resultLL = cmdLL.execute(parserLL);
+
+            if (logger.isDebugEnabled()) {
+                if (resultLL != null) {
+                    logger.debug("multipath -ll command failed: " + resultLL);
+                } else if (parserLL.getLines() != null) {
+                    logger.debug("multipath -ll output: " + parserLL.getLines());
+                } else {
+                    logger.debug("multipath -ll output is null");
+                }
+            }
+
+            if (resultLL == null && parserLL.getLines() != null && !parserLL.getLines().trim().isEmpty()) {
+                String[] lines = parserLL.getLines().split("\n");
+                for (String line : lines) {
+                    line = line.trim();
+                    if (line.isEmpty()) continue;
+
+                    // multipath -ll 출력 형식: "mpatha (360014056385a62fd8e80d45f7daf8ed7) dm-3 SYNOLOGY,Storage"
+                    if (line.contains("mpath") && (line.contains("dm-") || line.matches(".*mpath[a-z0-9]+.*"))) {
+                        String dmDevice = extractDmDeviceFromLine(line);
+                        String mpathName = extractMpathNameFromLine(line);
+                        String wwid = extractMpathWwidFromLine(line);
+                        String groupKey = wwid != null ? wwid : (mpathName != null ? mpathName : (dmDevice != null ? dmDevice : null));
+                        if (groupKey == null || addedMpathGroups.contains(groupKey)) continue;
+
+                        boolean useMapper = mpathName != null;
+                        if (useMapper) {
+                            try {
+                                if (!Files.exists(Path.of("/dev/mapper/" + mpathName))) useMapper = false;
+                            } catch (Exception e) { useMapper = false; }
+                        }
+                        if (!useMapper && dmDevice == null) continue;
+
+                        String chosenPath = useMapper ? "/dev/mapper/" + mpathName : "/dev/" + dmDevice;
+                        String preferredName = resolveDevicePathToById(chosenPath);
+                        String chosenKey = preferredName.startsWith("/dev/disk/by-id/") ?
+                            preferredName.substring(preferredName.lastIndexOf('/') + 1) : chosenPath;
+
+                        addMultipathDeviceToList(chosenPath, preferredName, names, texts, hasPartitionsList, scsiAddresses, scsiAddressCache, wwid);
+                        addedDevices.add(chosenKey);
+                        if (useMapper && dmDevice != null) {
+                            String dmPath = "/dev/" + dmDevice;
+                            String dmPreferred = resolveDevicePathToById(dmPath);
+                            String dmKey = dmPreferred.startsWith("/dev/disk/by-id/") ?
+                                dmPreferred.substring(dmPreferred.lastIndexOf('/') + 1) : dmPath;
+                            addedDevices.add(dmKey);
+                        }
+                        addedMpathGroups.add(groupKey);
+                        multipathDevicesAdded.incrementAndGet();
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Added multipath group (one entry): " + chosenPath + ", WWID=" + wwid);
+                        }
+                    }
+                }
+            } else {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("multipath -ll output is empty or failed");
+                }
+            }
+
+            // multipath -l 명령어로 mpath 디바이스 수집 (추가 확인)
+            Script cmd = null;
+            if (multipathPath != null) {
+                cmd = new Script(multipathPath);
+            } else {
+                cmd = new Script("/usr/sbin/multipath");
+            }
             cmd.add("-l");
             OutputInterpreter.AllLinesParser parser = new OutputInterpreter.AllLinesParser();
             String result = cmd.execute(parser);
 
-            if (result != null || parser.getLines() == null || parser.getLines().trim().isEmpty()) return;
+            if (logger.isDebugEnabled()) {
+                if (result != null) {
+                    logger.debug("multipath -l command failed: " + result);
+                } else if (parser.getLines() != null) {
+                    logger.debug("multipath -l output: " + parser.getLines());
+                } else {
+                    logger.debug("multipath -l output is null");
+                }
+            }
 
-            String[] lines = parser.getLines().split("\n");
-            for (String line : lines) {
-                if (line.contains("mpath")) {
-                    String dmDevice = extractDmDeviceFromLine(line);
-                    if (dmDevice != null) {
-                        String devicePath = "/dev/mapper/" + dmDevice;
-                        String preferredName = resolveDevicePathToById(devicePath);
+            if (result == null && parser.getLines() != null && !parser.getLines().trim().isEmpty()) {
+                String[] lines = parser.getLines().split("\n");
+                for (String line : lines) {
+                    line = line.trim();
+                    if (line.isEmpty()) continue;
 
-                        String deviceKey = preferredName.startsWith("/dev/disk/by-id/") ?
-                            preferredName.substring(preferredName.lastIndexOf('/') + 1) : devicePath;
+                    if (line.contains("mpath") && (line.contains("dm-") || line.matches(".*mpath[a-z0-9]+.*"))) {
+                        String dmDevice = extractDmDeviceFromLine(line);
+                        String mpathName = extractMpathNameFromLine(line);
+                        String wwid = extractMpathWwidFromLine(line);
+                        String groupKey = wwid != null ? wwid : (mpathName != null ? mpathName : (dmDevice != null ? dmDevice : null));
+                        if (groupKey == null || addedMpathGroups.contains(groupKey)) continue;
 
-                        if (!addedDevices.contains(deviceKey)) {
-                            addMultipathDeviceToList(devicePath, preferredName, names, texts, hasPartitionsList, scsiAddresses, scsiAddressCache);
-                            addedDevices.add(deviceKey);
+                        boolean useMapper = mpathName != null;
+                        if (useMapper) {
+                            try {
+                                if (!Files.exists(Path.of("/dev/mapper/" + mpathName))) useMapper = false;
+                            } catch (Exception e) { useMapper = false; }
                         }
+                        if (!useMapper && dmDevice == null) continue;
+
+                        String chosenPath = useMapper ? "/dev/mapper/" + mpathName : "/dev/" + dmDevice;
+                        String preferredName = resolveDevicePathToById(chosenPath);
+                        String chosenKey = preferredName.startsWith("/dev/disk/by-id/") ?
+                            preferredName.substring(preferredName.lastIndexOf('/') + 1) : chosenPath;
+
+                        addMultipathDeviceToList(chosenPath, preferredName, names, texts, hasPartitionsList, scsiAddresses, scsiAddressCache, wwid);
+                        addedDevices.add(chosenKey);
+                        if (useMapper && dmDevice != null) {
+                            String dmPath = "/dev/" + dmDevice;
+                            String dmPreferred = resolveDevicePathToById(dmPath);
+                            String dmKey = dmPreferred.startsWith("/dev/disk/by-id/") ?
+                                dmPreferred.substring(dmPreferred.lastIndexOf('/') + 1) : dmPath;
+                            addedDevices.add(dmKey);
+                        }
+                        addedMpathGroups.add(groupKey);
+                        multipathDevicesAdded.incrementAndGet();
                     }
                 }
             }
+
+            // /dev/mapper/ 스캔: -ll/-l에 없는 멀티패스 보충. 그룹당 1건만 추가 (mapper 우선), mapper+dm 키 등록
+            try {
+                Path mapperDir = Path.of("/dev/mapper");
+                if (Files.isDirectory(mapperDir)) {
+                    try (Stream<Path> stream = Files.list(mapperDir)) {
+                        stream.filter(Files::isSymbolicLink)
+                              .forEach(mapperLink -> {
+                                  try {
+                                      String linkName = mapperLink.getFileName().toString();
+                                      String devicePath = "/dev/mapper/" + linkName;
+                                      Path realPath = mapperLink.toRealPath();
+                                      String realDevicePath = realPath.toString();
+                                      String realDeviceName = realPath.getFileName().toString();
+
+                                      if (realDeviceName.startsWith("dm-") && realDevicePath.startsWith("/dev/")) {
+                                          boolean isMpathLink = linkName.startsWith("mpath");
+                                          boolean isMultipath = isMpathLink || isMultipathDevice(devicePath);
+                                          if (!isMultipath) return;
+
+                                          String preferredName = resolveDevicePathToById(devicePath);
+                                          String deviceKey = preferredName.startsWith("/dev/disk/by-id/") ?
+                                              preferredName.substring(preferredName.lastIndexOf('/') + 1) : devicePath;
+                                          if (addedDevices.contains(deviceKey)) return;
+
+                                          String dmDevicePath = "/dev/" + realDeviceName;
+                                          String dmPreferred = resolveDevicePathToById(dmDevicePath);
+                                          String dmKey = dmPreferred.startsWith("/dev/disk/by-id/") ?
+                                              dmPreferred.substring(dmPreferred.lastIndexOf('/') + 1) : dmDevicePath;
+
+                                          addMultipathDeviceToList(devicePath, preferredName, names, texts, hasPartitionsList, scsiAddresses, scsiAddressCache, null);
+                                          addedDevices.add(deviceKey);
+                                          addedDevices.add(dmKey);
+                                          multipathDevicesAdded.incrementAndGet();
+                                      }
+                                  } catch (Exception e) {
+                                  }
+                              });
+                    }
+                }
+            } catch (Exception e) {
+            }
+
+            // /dev/ 디렉토리에서 직접 dm-로 시작하는 블록 디바이스 확인
+            // multipath -l이나 /dev/mapper에서 누락될 수 있는 경우를 대비
+            try {
+                // /sys/block 디렉토리에서 dm-로 시작하는 디바이스 확인
+                File sysBlock = new File("/sys/block");
+                if (sysBlock.exists() && sysBlock.isDirectory()) {
+                    File[] entries = sysBlock.listFiles();
+                    if (entries != null) {
+                        for (File entry : entries) {
+                            String deviceName = entry.getName();
+                            if (deviceName.startsWith("dm-")) {
+                                try {
+                                    String devicePath = "/dev/" + deviceName;
+
+                                    // 이미 추가된 디바이스인지 확인
+                                    String preferredName = resolveDevicePathToById(devicePath);
+                                    String deviceKey = preferredName.startsWith("/dev/disk/by-id/") ?
+                                        preferredName.substring(preferredName.lastIndexOf('/') + 1) : devicePath;
+
+                                    if (!addedDevices.contains(deviceKey)) {
+                                        // multipath 디바이스인지 확인
+                                        if (isMultipathDevice(devicePath)) {
+                                            addMultipathDeviceToList(devicePath, preferredName, names, texts, hasPartitionsList, scsiAddresses, scsiAddressCache);
+                                            addedDevices.add(deviceKey);
+                                        }
+                                    }
+                                } catch (Exception e) {
+                                    // 개별 디바이스 처리 실패는 무시하고 계속 진행
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                // /sys/block 스캔 실패는 무시
+            }
         } catch (Exception e) {
+            logger.warn("Error collecting multipath devices", e);
         }
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Total multipath devices added: " + multipathDevicesAdded.get());
+            logger.debug("Final device names count: " + names.size());
+        }
+    }
+
+    private boolean isMultipathDevice(String devicePath) {
+        try {
+            String deviceName = Path.of(devicePath).getFileName().toString();
+
+            // /dev/mapper/에서 mpath로 시작하는 링크가 있는지 확인
+            if (devicePath.startsWith("/dev/dm-")) {
+                try {
+                    Path mapperDir = Path.of("/dev/mapper");
+                    if (Files.isDirectory(mapperDir)) {
+                        try (Stream<Path> stream = Files.list(mapperDir)) {
+                            boolean found = stream.filter(Files::isSymbolicLink)
+                                                  .anyMatch(link -> {
+                                                      try {
+                                                          Path realPath = link.toRealPath();
+                                                          return realPath.getFileName().toString().equals(deviceName) &&
+                                                                 link.getFileName().toString().startsWith("mpath");
+                                                      } catch (Exception e) {
+                                                          return false;
+                                                      }
+                                                  });
+                            if (found) {
+                                return true;
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // 확인 실패 시 다음 방법 시도
+                }
+            }
+
+            // dmsetup info로 multipath 디바이스인지 확인
+            Script cmd = new Script("/sbin/dmsetup");
+            cmd.add("info", devicePath);
+            OutputInterpreter.AllLinesParser parser = new OutputInterpreter.AllLinesParser();
+            String result = cmd.execute(parser);
+
+            if (result == null && parser.getLines() != null) {
+                String output = parser.getLines();
+                // multipath 타입인지 확인
+                if (output.contains("multipath") || output.contains("mpath")) {
+                    return true;
+                }
+            }
+
+            // multipath -ll로도 확인
+            Script multipathCmd = new Script("/usr/sbin/multipath");
+            multipathCmd.add("-ll");
+            OutputInterpreter.AllLinesParser multipathParser = new OutputInterpreter.AllLinesParser();
+            String multipathResult = multipathCmd.execute(multipathParser);
+
+            if (multipathResult == null && multipathParser.getLines() != null) {
+                if (multipathParser.getLines().contains(deviceName)) {
+                    return true;
+                }
+            }
+
+            // multipath -l 출력에서도 확인
+            Script multipathLCmd = new Script("/usr/sbin/multipath");
+            multipathLCmd.add("-l");
+            OutputInterpreter.AllLinesParser multipathLParser = new OutputInterpreter.AllLinesParser();
+            String multipathLResult = multipathLCmd.execute(multipathLParser);
+
+            if (multipathLResult == null && multipathLParser.getLines() != null) {
+                if (multipathLParser.getLines().contains(deviceName)) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            // 확인 실패 시 false 반환 (명확하지 않은 경우 제외)
+        }
+        return false;
     }
 
     private void addMultipathDeviceToList(String devicePath, String preferredName,
                                         List<String> names, List<String> texts, List<Boolean> hasPartitionsList,
                                         List<String> scsiAddresses, Map<String, String> scsiAddressCache) {
-        boolean hasPartition = hasPartitionRecursiveForDevice(devicePath);
+        addMultipathDeviceToList(devicePath, preferredName, names, texts, hasPartitionsList, scsiAddresses, scsiAddressCache, null);
+    }
 
-        StringBuilder deviceInfo = new StringBuilder();
-        deviceInfo.append("TYPE: multipath");
+    private void addMultipathDeviceToList(String devicePath, String preferredName,
+                                        List<String> names, List<String> texts, List<Boolean> hasPartitionsList,
+                                        List<String> scsiAddresses, Map<String, String> scsiAddressCache, String mpathWwid) {
+        try {
+            boolean hasPartition = hasPartitionRecursiveForDevice(devicePath);
 
-        String size = getDeviceSize(devicePath);
-        if (size != null) {
-            deviceInfo.append(" SIZE: ").append(size);
-        }
+            StringBuilder deviceInfo = new StringBuilder();
+            deviceInfo.append("TYPE: multipath");
 
-        deviceInfo.append(" HAS_PARTITIONS: ").append(hasPartition ? "true" : "false");
+            String size = getDeviceSize(devicePath);
+            if (size != null) {
+                deviceInfo.append(" SIZE: ").append(size);
+            }
 
-        String scsiAddress = scsiAddressCache.get(devicePath);
-        if (scsiAddress != null) {
-            deviceInfo.append(" SCSI_ADDRESS: ").append(scsiAddress);
-        }
+            deviceInfo.append(" HAS_PARTITIONS: ").append(hasPartition ? "true" : "false");
 
-        deviceInfo.append(" MULTIPATH_DEVICE: true");
+            String scsiAddress = scsiAddressCache.get(devicePath);
+            if (scsiAddress == null && preferredName != null && !preferredName.equals(devicePath)) {
+                scsiAddress = scsiAddressCache.get(preferredName);
+            }
+            if (scsiAddress != null) {
+                deviceInfo.append(" SCSI_ADDRESS: ").append(scsiAddress);
+            }
 
-        if (!preferredName.equals(devicePath) && preferredName.startsWith("/dev/disk/by-id/")) {
-            String byIdName = preferredName.substring(preferredName.lastIndexOf('/') + 1);
-            String displayName = devicePath + " (" + byIdName + ")";
+            if (mpathWwid != null && !mpathWwid.isEmpty()) {
+                deviceInfo.append(" MPATH_WWID: ").append(mpathWwid);
+            }
 
-            names.add(displayName);
-            texts.add(deviceInfo.toString());
-            hasPartitionsList.add(hasPartition);
-            scsiAddresses.add(scsiAddress != null ? scsiAddress : "");
-        } else {
+            if (!preferredName.equals(devicePath) && preferredName.startsWith("/dev/disk/by-id/")) {
+                String byIdName = preferredName.substring(preferredName.lastIndexOf('/') + 1);
+                String displayName = devicePath + " (" + byIdName + ")";
+
+                names.add(displayName);
+                texts.add(deviceInfo.toString());
+                hasPartitionsList.add(hasPartition);
+                scsiAddresses.add(scsiAddress != null ? scsiAddress : "");
+
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Added multipath device with by-id: " + displayName);
+                }
+            } else {
+                // by-id 경로가 없어도 기본 경로로 추가
+                names.add(devicePath);
+                texts.add(deviceInfo.toString());
+                hasPartitionsList.add(hasPartition);
+                scsiAddresses.add(scsiAddress != null ? scsiAddress : "");
+
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Added multipath device: " + devicePath);
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Error adding multipath device to list: " + devicePath, e);
+            // 에러가 발생해도 기본 정보라도 추가
+            try {
+                names.add(devicePath);
+                texts.add("TYPE: multipath");
+                hasPartitionsList.add(false);
+                scsiAddresses.add("");
+            } catch (Exception e2) {
+                // 최종 실패 시 로그만 남김
+                logger.warn("Failed to add multipath device even with minimal info: " + devicePath);
+            }
         }
     }
 
@@ -498,6 +818,35 @@ public abstract class ServerResourceBase implements ServerResource {
         }
 
         return null;
+    }
+
+    private String extractMpathNameFromLine(String line) {
+
+        // 먼저 정규식으로 전체 라인에서 추출 시도
+        Pattern pattern = Pattern.compile("\\b(mpath[a-z0-9]+)\\b");
+        Matcher matcher = pattern.matcher(line);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+
+        // 정규식이 실패하면 공백으로 분리하여 첫 번째 토큰 확인
+        String[] parts = line.trim().split("\\s+");
+        if (parts.length > 0 && parts[0].startsWith("mpath")) {
+            // mpatha, mpathb 같은 형식
+            Pattern mpathPattern = Pattern.compile("mpath[a-z0-9]+");
+            Matcher mpathMatcher = mpathPattern.matcher(parts[0]);
+            if (mpathMatcher.find()) {
+                return mpathMatcher.group();
+            }
+        }
+
+        return null;
+    }
+
+    /** multipath -ll/-l 라인에서 WWID 추출. 동일 WWID = 동일 멀티패스. 예: "mpatha (360014056385a62fd8e80d45f7daf8ed7) dm-3 ..." */
+    private String extractMpathWwidFromLine(String line) {
+        Matcher m = Pattern.compile("\\(([0-9a-fA-F]{32})\\)").matcher(line);
+        return m.find() ? m.group(1) : null;
     }
     private Map<Path, String> buildByIdReverseMap() {
         Map<Path, String> map = new HashMap<>();
@@ -853,10 +1202,90 @@ public abstract class ServerResourceBase implements ServerResource {
 
 
     private boolean hasPartitionRecursiveForDevice(String devicePath) {
+        try {
+            String deviceName = new File(devicePath).getName();
+            File sysBlockEntry = new File("/sys/block", deviceName);
+            if (sysBlockEntry.exists()) {
+                return sysHasPartitions(sysBlockEntry);
+            }
+
+            // lsblk로 확인
+            Script cmd = new Script("/usr/bin/lsblk");
+            cmd.add("--json", "--paths", "--output", "NAME,TYPE");
+            cmd.add(devicePath);
+            OutputInterpreter.AllLinesParser parser = new OutputInterpreter.AllLinesParser();
+            String result = cmd.execute(parser);
+
+            if (result == null && parser.getLines() != null) {
+                try {
+                    JSONObject json = new JSONObject(parser.getLines());
+                    JSONArray blockdevices = json.getJSONArray("blockdevices");
+                    if (blockdevices.length() > 0) {
+                        JSONObject device = blockdevices.getJSONObject(0);
+                        return hasPartitionRecursive(device);
+                    }
+                } catch (Exception e) {
+                    // JSON 파싱 실패 시 무시
+                }
+            }
+        } catch (Exception e) {
+            // 에러 발생 시 false 반환
+        }
         return false;
     }
 
     private String getDeviceSize(String devicePath) {
+        try {
+            String deviceName = new File(devicePath).getName();
+            File sysBlockEntry = new File("/sys/block", deviceName);
+            if (sysBlockEntry.exists()) {
+                String size = sysGetSizeHuman(sysBlockEntry);
+                if (size != null) {
+                    return size;
+                }
+            }
+
+            // lsblk로 확인
+            Script cmd = new Script("/usr/bin/lsblk");
+            cmd.add("--json", "--paths", "--output", "NAME,SIZE");
+            cmd.add(devicePath);
+            OutputInterpreter.AllLinesParser parser = new OutputInterpreter.AllLinesParser();
+            String result = cmd.execute(parser);
+
+            if (result == null && parser.getLines() != null) {
+                try {
+                    JSONObject json = new JSONObject(parser.getLines());
+                    JSONArray blockdevices = json.getJSONArray("blockdevices");
+                    if (blockdevices.length() > 0) {
+                        JSONObject device = blockdevices.getJSONObject(0);
+                        String size = device.optString("size", "");
+                        if (!size.isEmpty()) {
+                            return size;
+                        }
+                    }
+                } catch (Exception e) {
+                    // JSON 파싱 실패 시 무시
+                }
+            }
+
+            // blockdev 명령어로 확인
+            Script blockdevCmd = new Script("/sbin/blockdev");
+            blockdevCmd.add("--getsize64", devicePath);
+            OutputInterpreter.AllLinesParser blockdevParser = new OutputInterpreter.AllLinesParser();
+            String blockdevResult = blockdevCmd.execute(blockdevParser);
+
+            if (blockdevResult == null && blockdevParser.getLines() != null) {
+                try {
+                    long sizeBytes = Long.parseLong(blockdevParser.getLines().trim());
+                    double gib = sizeBytes / 1024.0 / 1024.0 / 1024.0;
+                    return String.format(Locale.ROOT, "%.2fG", gib);
+                } catch (Exception e) {
+                    // 파싱 실패 시 무시
+                }
+            }
+        } catch (Exception e) {
+            // 에러 발생 시 null 반환
+        }
         return null;
     }
 
@@ -1352,57 +1781,123 @@ public abstract class ServerResourceBase implements ServerResource {
             File[] entries = sysBlock.listFiles();
             if (entries == null) return;
 
+            Set<String> addedKeys = new HashSet<>();
+
             for (File e : entries) {
                 String bname = e.getName();
-                if (!(bname.startsWith("sd") || bname.startsWith("vd") || bname.startsWith("xvd"))) {
+
+                // 기본 SCSI 디스크(sd/vd/xvd) 처리
+                if (bname.startsWith("sd") || bname.startsWith("vd") || bname.startsWith("xvd")) {
+                    String dev = "/dev/" + bname;
+
+                    String sg = null;
+                    try {
+                        File sgDir = new File(e, "device/scsi_generic");
+                        File[] sgs = sgDir.listFiles();
+                        if (sgs != null && sgs.length > 0) {
+                            sg = "/dev/" + sgs[0].getName();
+                        }
+                    } catch (Exception ignore) {}
+
+                    String scsiAddress = scsiAddressCache.get(dev);
+                    if (scsiAddress == null) {
+                        try {
+                            Path devLink = Path.of(e.getAbsolutePath(), "device");
+                            Path real = Files.readSymbolicLink(devLink);
+                            Path resolved = devLink.getParent().resolve(real).normalize();
+                            scsiAddress = resolved.getFileName().toString();
+                        } catch (Exception ignore) {}
+                    }
+
+                    String vendor = readFirstLineQuiet(new File(e, "device/vendor"));
+                    String model = readFirstLineQuiet(new File(e, "device/model"));
+                    String rev = readFirstLineQuiet(new File(e, "device/rev"));
+
+                    String byId = resolveById(realToById, dev);
+
+                    StringBuilder text = new StringBuilder();
+                    text.append("SCSI_Address: ").append(scsiAddress != null ? ("[" + scsiAddress + "]") : "");
+                    text.append(" Type: disk");
+                    if (vendor != null) text.append(" Vendor: ").append(vendor);
+                    if (model != null) text.append(" Model: ").append(model);
+                    if (rev != null) text.append(" Revision: ").append(rev);
+                    text.append(" Device: ").append(dev);
+                    if (!byId.equals(dev)) text.append(" BY_ID: ").append(byId);
+
+                    String displayName = sg != null ? sg : dev;
+                    if (!byId.equals(dev)) {
+                        String byIdName = byId.substring(byId.lastIndexOf('/') + 1);
+                        displayName = (sg != null ? sg : dev) + " (" + byIdName + ")";
+                    }
+
+                    String key = displayName;
+                    if (!addedKeys.contains(key)) {
+                        names.add(displayName);
+                        texts.add(text.toString());
+                        hasPartitions.add(false);
+                        addedKeys.add(key);
+                    }
                     continue;
                 }
 
-                String dev = "/dev/" + bname;
+                // 멀티패스(dm-*) 디바이스를 SCSI 목록에 포함
+                if (bname.startsWith("dm-")) {
+                    String dev = "/dev/" + bname;
 
-                String sg = null;
-                try {
-                    File sgDir = new File(e, "device/scsi_generic");
-                    File[] sgs = sgDir.listFiles();
-                    if (sgs != null && sgs.length > 0) {
-                        sg = "/dev/" + sgs[0].getName();
+                    // 멀티패스 디바이스가 아니면 스킵
+                    if (!isMultipathDevice(dev)) {
+                        continue;
                     }
-                } catch (Exception ignore) {}
 
-                String scsiAddress = scsiAddressCache.get(dev);
-                if (scsiAddress == null) {
+                    String sg = null;
                     try {
-                        Path devLink = Path.of(e.getAbsolutePath(), "device");
-                        Path real = Files.readSymbolicLink(devLink);
-                        Path resolved = devLink.getParent().resolve(real).normalize();
-                        scsiAddress = resolved.getFileName().toString();
+                        File sgDir = new File(e, "device/scsi_generic");
+                        File[] sgs = sgDir.listFiles();
+                        if (sgs != null && sgs.length > 0) {
+                            sg = "/dev/" + sgs[0].getName();
+                        }
                     } catch (Exception ignore) {}
+
+                    String scsiAddress = scsiAddressCache.get(dev);
+                    if (scsiAddress == null) {
+                        try {
+                            Path devLink = Path.of(e.getAbsolutePath(), "device");
+                            Path real = Files.readSymbolicLink(devLink);
+                            Path resolved = devLink.getParent().resolve(real).normalize();
+                            scsiAddress = resolved.getFileName().toString();
+                        } catch (Exception ignore) {}
+                    }
+
+                    String vendor = readFirstLineQuiet(new File(e, "device/vendor"));
+                    String model = readFirstLineQuiet(new File(e, "device/model"));
+                    String rev = readFirstLineQuiet(new File(e, "device/rev"));
+
+                    String byId = resolveById(realToById, dev);
+
+                    StringBuilder text = new StringBuilder();
+                    text.append("SCSI_Address: ").append(scsiAddress != null ? ("[" + scsiAddress + "]") : "");
+                    text.append(" Type: disk");
+                    text.append(" Multipath: true");
+                    if (vendor != null) text.append(" Vendor: ").append(vendor);
+                    if (model != null) text.append(" Model: ").append(model);
+                    if (rev != null) text.append(" Revision: ").append(rev);
+                    text.append(" Device: ").append(dev);
+                    if (!byId.equals(dev)) text.append(" BY_ID: ").append(byId);
+
+                    String displayName = sg != null ? sg : dev;
+                    if (!byId.equals(dev)) {
+                        String byIdName = byId.substring(byId.lastIndexOf('/') + 1);
+                        displayName = (sg != null ? sg : dev) + " (" + byIdName + ")";
+                    }
+
+                    String key = displayName;
+                    if (!addedKeys.contains(key)) {
+                        names.add(displayName);
+                        texts.add(text.toString());
+                        hasPartitions.add(false);
+                        addedKeys.add(key);
+                    }
                 }
-
-                String vendor = readFirstLineQuiet(new File(e, "device/vendor"));
-                String model = readFirstLineQuiet(new File(e, "device/model"));
-                String rev = readFirstLineQuiet(new File(e, "device/rev"));
-
-                String byId = resolveById(realToById, dev);
-
-                StringBuilder text = new StringBuilder();
-                text.append("SCSI_Address: ").append(scsiAddress != null ? ("["+scsiAddress+"]") : "");
-                text.append(" Type: disk");
-                if (vendor != null) text.append(" Vendor: ").append(vendor);
-                if (model != null) text.append(" Model: ").append(model);
-                if (rev != null) text.append(" Revision: ").append(rev);
-                text.append(" Device: ").append(dev);
-                if (!byId.equals(dev)) text.append(" BY_ID: ").append(byId);
-
-                String displayName = sg != null ? sg : dev;
-                if (!byId.equals(dev)) {
-                    String byIdName = byId.substring(byId.lastIndexOf('/') + 1);
-                    displayName = (sg != null ? sg : dev) + " (" + byIdName + ")";
-                }
-
-                names.add(displayName);
-                texts.add(text.toString());
-                hasPartitions.add(false);
             }
         } catch (Exception e) {
         }
@@ -3186,14 +3681,11 @@ public abstract class ServerResourceBase implements ServerResource {
             OutputInterpreter.AllLinesParser parser = new OutputInterpreter.AllLinesParser();
             String result = dumpCommand.execute(parser);
 
-            if (result != null) {
+            if (result != null || parser.getLines() == null || parser.getLines().isEmpty()) {
                 return false;
             }
 
             String vmXml = parser.getLines();
-            if (vmXml == null || vmXml.isEmpty()) {
-                return false;
-            }
 
             String adapterName = extractDeviceNameFromScsiXml(xmlConfig);
             if (adapterName == null) {
@@ -3753,6 +4245,10 @@ public abstract class ServerResourceBase implements ServerResource {
 
     private String ensureUniqueLunTargetDev(String vmName, String xmlConfig) {
         try {
+            // 멀티패스: <target bus='scsi'/> (dev 없음) → 그대로 유지
+            if (Pattern.compile("<target\\s+bus='scsi'\\s*/?>").matcher(xmlConfig).find()) {
+                return xmlConfig;
+            }
             Matcher m = Pattern.compile("<target\\s+dev='(sd[a-z]+)'\\s+bus='scsi'\\s*/?>").matcher(xmlConfig);
             String current = null;
             if (m.find()) {
@@ -3760,9 +4256,11 @@ public abstract class ServerResourceBase implements ServerResource {
             }
             Set<String> used = getUsedScsiTargetDevs(vmName);
             if (current == null) {
-                // No target present: inject one with available dev after <source .../>
-                String chosen = pickAvailableScsiTargetDev(used);
-                return xmlConfig.replaceFirst("(</source>\\s*)", "$1\n  <target dev='" + chosen + "' bus='scsi'/>\n");
+                // target 없음: device='lun'(멀티패스)이면 dev 없이, 아니면 dev 주입
+                String inject = xmlConfig.contains("device='lun'")
+                    ? "<target bus='scsi'/>"
+                    : "<target dev='" + pickAvailableScsiTargetDev(used) + "' bus='scsi'/>";
+                return xmlConfig.replaceFirst("(</source>\\s*)", "$1\n  " + inject + "\n");
             }
             if (used.contains(current)) {
                 String chosen = pickAvailableScsiTargetDev(used);

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -3680,8 +3680,16 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
                     _hostDetailsDao.persist(allocationDetail);
                 }
 
-                // VM extraconfig에 디바이스 설정 추가
-                addDeviceToVmExtraConfig(vmId, hostDeviceName, xmlConfig);
+                String xmlToStore = lunAnswer.getXmlConfig() != null ? lunAnswer.getXmlConfig() : xmlConfig;
+                boolean invalidLunTarget = xmlToStore != null && xmlToStore.contains("device='lun'")
+                    && (xmlToStore.contains("dev='mapper/") || xmlToStore.contains("dev=\"mapper/")
+                        || (xmlToStore.contains("mpath") && xmlToStore.contains("<target")));
+                if (invalidLunTarget) {
+                    xmlToStore = null;
+                }
+                if (xmlToStore != null) {
+                    addDeviceToVmExtraConfig(vmId, hostDeviceName, xmlToStore);
+                }
 
             }
 

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -3615,6 +3616,35 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
                     // VM extraconfig에서 해당 디바이스 설정 제거
                     if (vmIdToRemove != null && !vmIdToRemove.trim().isEmpty()) {
                         removeDeviceFromVmExtraConfig(Long.parseLong(vmIdToRemove), hostDeviceName, xmlConfig);
+
+                        // LUN 디바이스 삭제 시 함께 삭제되는 SCSI 디바이스의 extraconfig도 삭제
+                        try {
+                            // 같은 VM에 할당된 모든 디바이스 할당 정보 조회
+                            SearchCriteria<DetailVO> sc = _hostDetailsDao.createSearchCriteria();
+                            sc.addAnd("hostId", SearchCriteria.Op.EQ, hostId);
+                            sc.addAnd("value", SearchCriteria.Op.EQ, vmIdToRemove);
+                            List<DetailVO> allAllocations = _hostDetailsDao.search(sc, null);
+
+                            // SCSI 디바이스 중에서 같은 물리 디바이스에 매핑된 것 찾기
+                            for (DetailVO allocation : allAllocations) {
+                                String deviceName = extractDeviceNameFromStoredKey(allocation.getName());
+                                if (isScsiDevice(deviceName)) {
+                                    // SCSI 디바이스의 물리 경로 추출
+                                    String scsiPhysicalPath = extractPhysicalDeviceFromScsi(deviceName);
+                                    if (scsiPhysicalPath != null) {
+                                        // LUN 디바이스 이름과 SCSI 디바이스의 물리 경로를 비교하여 같은 물리 디바이스인지 확인
+                                        if (isSamePhysicalDevice(hostDeviceName, scsiPhysicalPath)) {
+                                            // 같은 물리 디바이스에 매핑된 SCSI 디바이스의 extraconfig 삭제
+                                            removeDeviceFromVmExtraConfig(Long.parseLong(vmIdToRemove), deviceName, "");
+                                            // host_details에서 SCSI 할당 레코드도 삭제 (가상머신 설정과 동기화)
+                                            _hostDetailsDao.remove(allocation.getId());
+                                        }
+                                    }
+                                }
+                            }
+                        } catch (Exception e) {
+                            logger.warn("Error removing SCSI device extraconfig for LUN device {}: {}", hostDeviceName, e.getMessage());
+                        }
                     }
                 }
             } else {
@@ -8999,6 +9029,71 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
     }
 
     /**
+     * SCSI hostdev XML 값에서 source dev 경로를 추출합니다.
+     * e.g. &lt;source dev='/dev/sg2'/&gt; or &lt;source dev="/dev/sg2"/&gt;
+     */
+    private String extractScsiDevPathFromXml(String xmlValue) {
+        if (xmlValue == null || xmlValue.isEmpty()) {
+            return null;
+        }
+        try {
+            int devIdx = xmlValue.indexOf("dev='");
+            if (devIdx >= 0) {
+                int start = devIdx + 5;
+                int end = xmlValue.indexOf("'", start);
+                if (end > start) {
+                    return xmlValue.substring(start, end).trim();
+                }
+            }
+            devIdx = xmlValue.indexOf("dev=\"");
+            if (devIdx >= 0) {
+                int start = devIdx + 5;
+                int end = xmlValue.indexOf("\"", start);
+                if (end > start) {
+                    return xmlValue.substring(start, end).trim();
+                }
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+        return null;
+    }
+
+    /**
+     * SCSI hostdev XML에서 adapter 이름과 address(bus/target/unit) 조합을 추출해
+     * 하나의 키 문자열로 반환한다.
+     * 예) "scsi_host16|0:0:1"
+     */
+    private String extractScsiAdapterAddressKey(String xmlValue) {
+        if (xmlValue == null || xmlValue.isEmpty()) {
+            return null;
+        }
+        try {
+            Pattern adapterPattern = Pattern.compile("<adapter\\s+name=['\"]([^'\"]+)['\"][^>]*>", Pattern.CASE_INSENSITIVE);
+            Pattern addressPattern = Pattern.compile(
+                    "<address\\s+[^>]*bus=['\"]([^'\"]+)['\"][^>]*target=['\"]([^'\"]+)['\"][^>]*unit=['\"]([^'\"]+)['\"][^>]*>",
+                    Pattern.CASE_INSENSITIVE);
+
+            Matcher adapterMatcher = adapterPattern.matcher(xmlValue);
+            Matcher addressMatcher = addressPattern.matcher(xmlValue);
+
+            if (adapterMatcher.find() && addressMatcher.find()) {
+                String adapter = adapterMatcher.group(1).trim();
+                String bus = addressMatcher.group(1).trim();
+                String target = addressMatcher.group(2).trim();
+                String unit = addressMatcher.group(3).trim();
+
+                if (!adapter.isEmpty() && !bus.isEmpty() && !target.isEmpty() && !unit.isEmpty()) {
+                    return (adapter + "|" + bus + ":" + target + ":" + unit).toLowerCase();
+                }
+            }
+        } catch (Exception e) {
+            // 패턴 파싱 실패는 무시하고 null 반환
+        }
+        return null;
+    }
+
+    /**
      * Removes device configuration from VM extraconfig.
      */
     private void removeDeviceFromVmExtraConfig(Long vmId, String deviceName, String xmlConfig) {
@@ -9006,6 +9101,9 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             List<UserVmDetailVO> existingConfigs = _vmDetailsDao.listDetails(vmId);
 
             boolean removed = false;
+            // SCSI extraconfig 후보들을 모아두었다가, 어떤 것도 매칭되지 않을 경우
+            // "단 하나만 존재하는 SCSI extraconfig" 라면 안전하게 제거하기 위한 리스트
+            List<UserVmDetailVO> scsiCandidates = new ArrayList<>();
 
             for (UserVmDetailVO detail : existingConfigs) {
                 if (detail.getName().startsWith("extraconfig-") && detail.getValue() != null) {
@@ -9052,15 +9150,91 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
                         }
                     } else if (isScsiDevice(deviceName)) {
 
+                        // 1) LUN 경로에서 매핑된 SCSI extraconfig를 정리할 때:
+                        //    xmlConfig 는 비어 있고, 이미 상위 로직에서 "같은 물리 디바이스"인 SCSI 만 선별한 상태이므로
+                        //    여기서는 해당 VM 의 SCSI extraconfig 를 과감하게 제거해도 안전하다.
+                        if (!shouldRemove && (xmlConfig == null || xmlConfig.trim().isEmpty())) {
+                            if (value != null &&
+                                    (value.contains("type='scsi'") || value.contains("type=\"scsi\""))) {
+                                shouldRemove = true;
+                                matchReason = "SCSI extraconfig for mapped LUN device";
+                            }
+                        }
 
-                        if (xmlConfig != null && !xmlConfig.trim().isEmpty()) {
-
+                        // 2) SCSI 탭에서 직접 삭제하는 경우 등, xmlConfig 가 넘어오는 경우:
+                        //    2-1) XML 전체 문자열 비교
+                        //    2-2) adapter name + address(bus/target/unit) 조합으로 매칭
+                            if (!shouldRemove && xmlConfig != null && !xmlConfig.trim().isEmpty()) {
                             String normalizedStoredXml = value.replaceAll("\\s+", "").toLowerCase();
                             String normalizedInputXml = xmlConfig.replaceAll("\\s+", "").toLowerCase();
 
                             if (normalizedStoredXml.equals(normalizedInputXml)) {
                                 shouldRemove = true;
                                 matchReason = "SCSI XML exact match";
+                            }
+
+                            if (!shouldRemove) {
+                                String storedKey = extractScsiAdapterAddressKey(value);
+                                String inputKey = extractScsiAdapterAddressKey(xmlConfig);
+                                if (storedKey != null && storedKey.equals(inputKey)) {
+                                    shouldRemove = true;
+                                    matchReason = "SCSI adapter/address match";
+                                }
+                            }
+
+                            // 2-3) 어댑터/어드레스 키를 만들지 못한 경우(속성 순서 변경 등)를 위한 보강 매칭
+                            if (!shouldRemove) {
+                                String inputKey = extractScsiAdapterAddressKey(xmlConfig);
+                                if (inputKey != null) {
+                                    String[] parts = inputKey.split("\\|");
+                                    if (parts.length == 2) {
+                                        String adapter = parts[0];
+                                        String addr = parts[1]; // bus:target:unit
+                                        String[] addrParts = addr.split(":");
+                                        if (addrParts.length == 3) {
+                                            String bus = addrParts[0];
+                                            String target = addrParts[1];
+                                            String unit = addrParts[2];
+
+                                            String storedLower = value.toLowerCase();
+                                            boolean adapterMatch = storedLower.contains("<adapter") && storedLower.contains("name='" + adapter + "'")
+                                                    || storedLower.contains("name=\"" + adapter + "\"");
+                                            boolean busMatch = storedLower.contains("bus='" + bus + "'") || storedLower.contains("bus=\"" + bus + "\"");
+                                            boolean targetMatch = storedLower.contains("target='" + target + "'") || storedLower.contains("target=\"" + target + "\"");
+                                            boolean unitMatch = storedLower.contains("unit='" + unit + "'") || storedLower.contains("unit=\"" + unit + "\"");
+
+                                            if (adapterMatch && busMatch && targetMatch && unitMatch) {
+                                                shouldRemove = true;
+                                                matchReason = "SCSI adapter/address attribute match (order-insensitive)";
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // 3) 그래도 못 찾으면 마지막으로 디바이스 이름 / dev 경로 기반 매칭 시도
+                        if (!shouldRemove) {
+                            // SCSI 디바이스 이름이 XML에 포함되어 있는지 확인
+                            if (value.contains(deviceName)) {
+                                shouldRemove = true;
+                                matchReason = "SCSI device name match";
+                            } else {
+                                // extraconfig XML에서 source dev 경로를 추출하여 해당 SCSI 디바이스와 일치하는지 확인
+                                String devPathInXml = extractScsiDevPathFromXml(value);
+                                if (devPathInXml != null && devPathInXml.equals(deviceName)) {
+                                    shouldRemove = true;
+                                    matchReason = "SCSI device path match from XML";
+                                }
+                            }
+                        }
+
+                        // 매칭에 실패했지만, SCSI hostdev XML 인 경우 후보로 모아둔다.
+                        // 나중에 후보가 하나뿐이면 보수적으로 제거한다.
+                        if (!shouldRemove) {
+                            String lower = value.toLowerCase(Locale.ROOT);
+                            if (lower.contains("<hostdev") && (lower.contains("type='scsi'") || lower.contains("type=\"scsi\""))) {
+                                scsiCandidates.add(detail);
                             }
                         }
                     } else if (isHbaDevice(deviceName)) {
@@ -9106,6 +9280,20 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
                         }
                         break;
                     }
+                }
+            }
+
+            // SCSI 디바이스인데 위의 매칭으로도 아무것도 지우지 못했고,
+            // extraconfig 안에 SCSI hostdev 가 단 하나만 있다면,
+            // 그 엔트리가 이 디바이스에 해당하는 것으로 보고 제거한다.
+            if (!removed && isScsiDevice(deviceName) && scsiCandidates.size() == 1) {
+                UserVmDetailVO only = scsiCandidates.get(0);
+                try {
+                    _vmDetailsDao.remove(only.getId());
+                    removed = true;
+                    logger.info("Removed lone SCSI extraconfig entry for VM {}, device: {} as a safe fallback.", vmId, deviceName);
+                } catch (Exception ex) {
+                    logger.warn("Failed to remove lone SCSI extraconfig entry for VM " + vmId + ", device " + deviceName + ": " + ex.getMessage(), ex);
                 }
             }
 

--- a/ui/src/views/infra/ListHostDevicesTab.vue
+++ b/ui/src/views/infra/ListHostDevicesTab.vue
@@ -718,13 +718,10 @@ export default {
         const deviceName = String(item.hostDevicesName || '')
         const deviceText = String(item.hostDevicesText || '')
 
-        if (deviceName.toUpperCase().includes('LUN') || deviceName.toLowerCase().includes('dm')) {
-          return false
-        }
-
         const isLun = deviceName.startsWith('/dev/') ||
                      deviceName.startsWith('wwn-') ||
                      deviceName.startsWith('scsi-') ||
+                     deviceName.startsWith('dm-') ||
                      deviceName.startsWith('nvme-')
         if (!query) return isLun
         return isLun && (


### PR DESCRIPTION
### PR 설명

<img width="1089" height="248" alt="image" src="https://github.com/user-attachments/assets/5ef9df64-2e45-40e7-a348-52b042d08c70" />
- 동일 LUN의 중복 경로를 multipath로 통합하여 단일 디바이스로 가져옴

- LUN 디바이스 탭에서 SCSI 디바이스 삭제 시 extraconfig 값이 제거되지 않던 문제 수정

- 멀티패스 디바이스 할당 및 해제 기능 추가

### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [ ] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [X] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [x] 주요 기능/개선
- [ ] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [ ] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [ ] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->


