### PR TITLE
ablestack-europa 빌드 테스트 실패 수정

### DIFF
--- a/developer/design/ablestack-v2k-n2k-cloud-import-integration.ko.md
+++ b/developer/design/ablestack-v2k-n2k-cloud-import-integration.ko.md
@@ -1,3 +1,21 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 # ABLESTACK v2k/n2k Cloud Import Integration Design
 
 ## 1. 목표

--- a/developer/design/import-vm-task-actions-design.md
+++ b/developer/design/import-vm-task-actions-design.md
@@ -1,3 +1,21 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 # Import VM Task Action Design
 
 ## Goal

--- a/developer/design/import-vm-task-sync-progress-design.md
+++ b/developer/design/import-vm-task-sync-progress-design.md
@@ -1,3 +1,21 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 # Import VM Task Sync Progress Design
 
 ## Goal

--- a/developer/design/n2k-cloud-background-execution.md
+++ b/developer/design/n2k-cloud-background-execution.md
@@ -1,3 +1,21 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 # N2K Cloud Background Execution Alignment
 
 ## Goal

--- a/developer/history/main-to-europa-2026-baseline-pretriage-2026-04-23.tsv
+++ b/developer/history/main-to-europa-2026-baseline-pretriage-2026-04-23.tsv
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 sha	date	subject	pretriage_status	detail
 3166e64891fc75d4d32b66d874cff3f613b09b52	2026-04-17	Add support for new variables to the GUI whitelabel runtime system (#12760)	documented	already present in tracker
 f820d0125de3f34977cb55d8a388388f04586452	2026-04-17	fix end of files and codespell errors	needs_source_review	

--- a/developer/history/main-to-europa-2026-only-inventory-2026-04-23.txt
+++ b/developer/history/main-to-europa-2026-only-inventory-2026-04-23.txt
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 3166e64891fc75d4d32b66d874cff3f613b09b52 2026-04-17 Add support for new variables to the GUI whitelabel runtime system (#12760)
 f820d0125de3f34977cb55d8a388388f04586452 2026-04-17 fix end of files and codespell errors
 83f705ddc58841991e01436210d64bef55d98f52 2026-04-16 Static Routes with nexthop non-functional for private gateways (#12859)

--- a/developer/history/main-to-europa-candidate-tracker-2026-04-23.ko.md
+++ b/developer/history/main-to-europa-candidate-tracker-2026-04-23.ko.md
@@ -1,3 +1,21 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 # `main -> ablestack-europa` 체리픽 후보 추적 문서
 
 ## 목적

--- a/developer/history/ui-test-review-checklist-2026-04-17-plus.ko.md
+++ b/developer/history/ui-test-review-checklist-2026-04-17-plus.ko.md
@@ -1,3 +1,21 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 # UI 테스트 / 검토 체크리스트 - `2026-04-17` 이후 `ablestack-europa`
 
 ## 목적

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -1137,14 +1137,18 @@ public class LibvirtComputingResourceTest {
         final LibvirtRequestWrapper wrapper = LibvirtRequestWrapper.getInstance();
         assertNotNull(wrapper);
 
-        final Answer answer = wrapper.execute(command, libvirtComputingResourceMock);
-        assertTrue(answer.getResult());
+        try (MockedStatic<Script> ignored = Mockito.mockStatic(Script.class)) {
+            Mockito.when(Script.runSimpleBashScript(Mockito.anyString(), Mockito.anyInt())).thenReturn("Job type: None");
 
-        verify(libvirtComputingResourceMock, times(1)).getLibvirtUtilitiesHelper();
-        try {
-            verify(libvirtUtilitiesHelper, times(1)).getConnectionByVmName(vmName);
-        } catch (final LibvirtException e) {
-            fail(e.getMessage());
+            final Answer answer = wrapper.execute(command, libvirtComputingResourceMock);
+            assertTrue(answer.getResult());
+
+            verify(libvirtComputingResourceMock, times(1)).getLibvirtUtilitiesHelper();
+            try {
+                verify(libvirtUtilitiesHelper, times(1)).getConnectionByVmName(vmName);
+            } catch (final LibvirtException e) {
+                fail(e.getMessage());
+            }
         }
     }
 

--- a/server/src/test/java/com/cloud/storage/snapshot/SnapshotManagerTest.java
+++ b/server/src/test/java/com/cloud/storage/snapshot/SnapshotManagerTest.java
@@ -58,6 +58,7 @@ import com.cloud.vm.snapshot.VMSnapshotVO;
 import com.cloud.vm.snapshot.dao.VMSnapshotDao;
 
 import org.apache.cloudstack.api.command.user.snapshot.ExtractSnapshotCmd;
+import org.apache.cloudstack.backup.dao.BackupDao;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
@@ -200,6 +201,8 @@ public class SnapshotManagerTest {
     ImageStoreEntity imageStoreEntityMock;
     @Mock
     DataStoreManager dataStoreManagerMock;
+    @Mock
+    BackupDao backupDao;
 
     SnapshotPolicyVO snapshotPolicyVoInstance;
 
@@ -233,6 +236,7 @@ public class SnapshotManagerTest {
         when(_volumeDao.findById(anyLong())).thenReturn(volumeMock);
         when(volumeMock.getState()).thenReturn(Volume.State.Ready);
         when(volumeMock.getId()).thenReturn(TEST_VOLUME_ID);
+        when(backupDao.listByVmId(nullable(Long.class), anyLong())).thenReturn(Collections.emptyList());
         when(volumeFactory.getVolume(anyLong())).thenReturn(volumeInfoMock);
         when(volumeInfoMock.getDataStore()).thenReturn(storeMock);
         when(volumeInfoMock.getState()).thenReturn(Volume.State.Ready);

--- a/server/src/test/java/com/cloud/template/HypervisorTemplateAdapterTest.java
+++ b/server/src/test/java/com/cloud/template/HypervisorTemplateAdapterTest.java
@@ -51,6 +51,8 @@ import org.apache.cloudstack.framework.events.EventDistributor;
 import org.apache.cloudstack.framework.messagebus.MessageBus;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreVO;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreVO;
 import org.apache.cloudstack.storage.heuristics.HeuristicRuleHelper;
 import org.apache.cloudstack.storage.image.datastore.ImageStoreEntity;
 import org.apache.logging.log4j.Logger;
@@ -112,6 +114,9 @@ public class HypervisorTemplateAdapterTest {
     TemplateDataStoreDao _templateStoreDao;
 
     @Mock
+    ImageStoreDao _imgStoreDao;
+
+    @Mock
     UsageEventDao _usageEventDao;
 
     @Mock
@@ -160,6 +165,10 @@ public class HypervisorTemplateAdapterTest {
         closeable = MockitoAnnotations.openMocks(this);
         ReflectionTestUtils.setField(_adapter, "storeMgr", dataStoreManagerMock);
         ReflectionTestUtils.setField(_adapter, "_statsCollector", statsCollectorMock);
+        ReflectionTestUtils.setField(_adapter, "_imgStoreDao", _imgStoreDao);
+        ImageStoreVO imageStoreVO = Mockito.mock(ImageStoreVO.class);
+        Mockito.when(imageStoreVO.isReadonly()).thenReturn(false);
+        Mockito.when(_imgStoreDao.findById(Mockito.anyLong())).thenReturn(imageStoreVO);
     }
 
     @After
@@ -466,12 +475,9 @@ public class HypervisorTemplateAdapterTest {
         Set<Long> zoneSet = null;
         boolean isTemplatePrivate = false;
         DataCenterVO dataCenterVOMock = Mockito.mock(DataCenterVO.class);
-        DataStore writableStoreMock = Mockito.mock(DataStore.class);
-        Mockito.when(writableStoreMock.getId()).thenReturn(1L);
 
         Mockito.when(_dcDao.findById(Mockito.anyLong())).thenReturn(dataCenterVOMock);
         Mockito.when(dataCenterVOMock.getAllocationState()).thenReturn(Grouping.AllocationState.Enabled);
-        Mockito.when(dataStoreManagerMock.getImageStoresByScopeExcludingReadOnly(Mockito.any())).thenReturn(List.of(writableStoreMock));
         Mockito.when(statsCollectorMock.imageStoreHasEnoughCapacity(any(DataStore.class))).thenReturn(false);
 
         boolean result = _adapter.isZoneAndImageStoreAvailable(dataStoreMock, zoneId, zoneSet, isTemplatePrivate);
@@ -489,12 +495,9 @@ public class HypervisorTemplateAdapterTest {
         Set<Long> zoneSet = null;
         boolean isTemplatePrivate = false;
         DataCenterVO dataCenterVOMock = Mockito.mock(DataCenterVO.class);
-        DataStore writableStoreMock = Mockito.mock(DataStore.class);
-        Mockito.when(writableStoreMock.getId()).thenReturn(1L);
 
         Mockito.when(_dcDao.findById(Mockito.anyLong())).thenReturn(dataCenterVOMock);
         Mockito.when(dataCenterVOMock.getAllocationState()).thenReturn(Grouping.AllocationState.Enabled);
-        Mockito.when(dataStoreManagerMock.getImageStoresByScopeExcludingReadOnly(Mockito.any())).thenReturn(List.of(writableStoreMock));
         Mockito.when(statsCollectorMock.imageStoreHasEnoughCapacity(any(DataStore.class))).thenReturn(true);
 
         boolean result = _adapter.isZoneAndImageStoreAvailable(dataStoreMock, zoneId, zoneSet, isTemplatePrivate);
@@ -512,12 +515,9 @@ public class HypervisorTemplateAdapterTest {
         Set<Long> zoneSet = Set.of(1L);
         boolean isTemplatePrivate = true;
         DataCenterVO dataCenterVOMock = Mockito.mock(DataCenterVO.class);
-        DataStore writableStoreMock = Mockito.mock(DataStore.class);
-        Mockito.when(writableStoreMock.getId()).thenReturn(1L);
 
         Mockito.when(_dcDao.findById(Mockito.anyLong())).thenReturn(dataCenterVOMock);
         Mockito.when(dataCenterVOMock.getAllocationState()).thenReturn(Grouping.AllocationState.Enabled);
-        Mockito.when(dataStoreManagerMock.getImageStoresByScopeExcludingReadOnly(Mockito.any())).thenReturn(List.of(writableStoreMock));
         Mockito.when(statsCollectorMock.imageStoreHasEnoughCapacity(any(DataStore.class))).thenReturn(true);
 
         boolean result = _adapter.isZoneAndImageStoreAvailable(dataStoreMock, zoneId, zoneSet, isTemplatePrivate);
@@ -535,12 +535,9 @@ public class HypervisorTemplateAdapterTest {
         Set<Long> zoneSet = new HashSet<>();
         boolean isTemplatePrivate = true;
         DataCenterVO dataCenterVOMock = Mockito.mock(DataCenterVO.class);
-        DataStore writableStoreMock = Mockito.mock(DataStore.class);
-        Mockito.when(writableStoreMock.getId()).thenReturn(1L);
 
         Mockito.when(_dcDao.findById(Mockito.anyLong())).thenReturn(dataCenterVOMock);
         Mockito.when(dataCenterVOMock.getAllocationState()).thenReturn(Grouping.AllocationState.Enabled);
-        Mockito.when(dataStoreManagerMock.getImageStoresByScopeExcludingReadOnly(Mockito.any())).thenReturn(List.of(writableStoreMock));
         Mockito.when(statsCollectorMock.imageStoreHasEnoughCapacity(any(DataStore.class))).thenReturn(true);
 
         boolean result = _adapter.isZoneAndImageStoreAvailable(dataStoreMock, zoneId, zoneSet, isTemplatePrivate);

--- a/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
+++ b/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
@@ -3658,11 +3658,6 @@ public class UserVmManagerImplTest {
         when(vm.getId()).thenReturn(vmId);
         when(vm.getState()).thenReturn(VirtualMachine.State.Running);
         when(vm.getTemplateId()).thenReturn(templateId);
-        BackupVO backup = mock(BackupVO.class);
-        when(backupDao.findById(backupId)).thenReturn(backup);
-        when(backup.getBackupOfferingId()).thenReturn(2L);
-        when(backupManager.getBackupProviderForOffering(2L)).thenReturn(null);
-
         when(backupManager.restoreBackupToVM(backupId, vmId)).thenReturn(true);
 
         Map<VirtualMachineProfile.Param, Object> params = new HashMap<>();

--- a/server/src/test/java/com/cloud/vm/snapshot/VMSnapshotManagerTest.java
+++ b/server/src/test/java/com/cloud/vm/snapshot/VMSnapshotManagerTest.java
@@ -63,6 +63,7 @@ import com.cloud.vm.snapshot.dao.VMSnapshotDetailsDao;
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.api.ResourceDetail;
+import org.apache.cloudstack.backup.dao.BackupDao;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
@@ -74,6 +75,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -89,6 +91,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -144,6 +147,8 @@ public class VMSnapshotManagerTest {
     VMSnapshotDetailsDao _vmSnapshotDetailsDao;
     @Mock
     UserVmManager _userVmManager;
+    @Mock
+    BackupDao backupDao;
     @Mock
     DiskOfferingDao _diskOfferingDao;
     @Mock
@@ -212,10 +217,12 @@ public class VMSnapshotManagerTest {
         _vmSnapshotMgr._vmSnapshotDetailsDao = _vmSnapshotDetailsDao;
         _vmSnapshotMgr._userVmManager = _userVmManager;
         _vmSnapshotMgr._diskOfferingDao = _diskOfferingDao;
+        ReflectionTestUtils.setField(_vmSnapshotMgr, "backupDao", backupDao);
 
         when(_userVMDao.findById(anyLong())).thenReturn(vmMock);
         when(_vmSnapshotDao.findByName(anyLong(), anyString())).thenReturn(null);
         when(_vmSnapshotDao.findByVm(anyLong())).thenReturn(new ArrayList<VMSnapshotVO>());
+        when(backupDao.listByVmId(nullable(Long.class), anyLong())).thenReturn(new ArrayList<>());
         when(_hypervisorCapabilitiesDao.isVmSnapshotEnabled(Hypervisor.HypervisorType.XenServer, "default")).thenReturn(true);
         when(_serviceOfferingDetailsDao.findDetail(anyLong(), anyString())).thenReturn(null);
 

--- a/server/src/test/java/org/apache/cloudstack/backup/BackupManagerTest.java
+++ b/server/src/test/java/org/apache/cloudstack/backup/BackupManagerTest.java
@@ -708,7 +708,7 @@ public class BackupManagerTest {
         when(backup.getId()).thenReturn(backupId);
         when(backup.getSize()).thenReturn(newBackupSize);
         when(backupProvider.getName()).thenReturn("testbackupprovider");
-        when(backupProvider.takeBackup(vmInstanceVOMock, null, scheduleId)).thenReturn(new Pair<>(true, backup));
+        when(backupProvider.takeBackup(vmInstanceVOMock, null)).thenReturn(new Pair<>(true, backup));
         Map<String, BackupProvider> backupProvidersMap = new HashMap<>();
         backupProvidersMap.put(backupProvider.getName().toLowerCase(), backupProvider);
         ReflectionTestUtils.setField(backupManager, "backupProvidersMap", backupProvidersMap);
@@ -854,15 +854,21 @@ public class BackupManagerTest {
 
         BackupProvider backupProvider = mock(BackupProvider.class);
         when(backupProvider.getName()).thenReturn("testbackupprovider");
+        when(backupProvider.supportsBackgroundSync()).thenReturn(true);
+        when(backupProvider.supportsOutOfBandBackupSync()).thenReturn(true);
         backupManager.setBackupProviders(List.of(backupProvider));
         backupManager.start();
 
         VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
         when(vm.getId()).thenReturn(vmId);
         when(vm.getAccountId()).thenReturn(accountId);
+        when(vm.getBackupOfferingId()).thenReturn(1L);
         List<Long> vmIds = List.of(vmId);
         when(backupDao.listVmIdsWithBackupsInZone(dataCenterId)).thenReturn(vmIds);
         when(vmInstanceDao.listByZoneAndBackupOffering(dataCenterId, null)).thenReturn(List.of(vm));
+        BackupOfferingVO backupOffering = mock(BackupOfferingVO.class);
+        when(backupOffering.getProvider()).thenReturn("testbackupprovider");
+        when(backupOfferingDao.findById(1L)).thenReturn(backupOffering);
 
         Backup.RestorePoint restorePoint1 = new Backup.RestorePoint(restorePoint1ExternalId, DateUtil.now(), "Full", restorePointSize, 0L);
         Backup.RestorePoint restorePoint2 = new Backup.RestorePoint("12345", DateUtil.now(), "Full", restorePointSize, 0L);


### PR DESCRIPTION
## 개요

`ablestack-europa` 브랜치의 GitHub Actions Build 실패를 수정합니다. 이번 변경은 제품 동작 코드가 아니라 테스트 코드 안정화에 한정됩니다.

## 변경 내용

- `SnapshotManagerTest`, `VMSnapshotManagerTest`에서 VM backup 조회 의존성(`BackupDao`)을 현재 서비스 로직에 맞게 mock 처리했습니다.
- `HypervisorTemplateAdapterTest`에서 이미지 스토어 read-only 판정 의존성(`ImageStoreDao`, `ImageStoreVO`)을 테스트에 주입했습니다.
- `UserVmManagerImplTest`의 불필요한 stub을 정리해 Mockito strict stubbing 실패를 제거했습니다.
- `BackupManagerTest`에서 변경된 `takeBackup` 호출 시그니처와 background sync capability 확인 흐름을 반영했습니다.
- `LibvirtComputingResourceTest#testGetVmStatsCommand`에서 `virsh domjobinfo` 실행 결과에 의존하던 부분을 static mock으로 고정해 GitHub Actions runner 환경에 흔들리지 않도록 했습니다.

## DB 변경 사항

없습니다.

- 신규 테이블: 없음
- 변경 테이블: 없음
- 신규 컬럼: 없음
- 변경 컬럼: 없음
- 스키마 마이그레이션 필요 여부: 없음

따라서 DB 업데이트 누락으로 인한 503 유발 가능성은 없습니다.

## 검증

- 로컬 targeted server 테스트 통과
  - `BackupManagerTest`
  - `VMSnapshotManagerTest`
  - `SnapshotManagerTest`
  - `HypervisorTemplateAdapterTest`
  - `UserVmManagerImplTest`
- 로컬 KVM 테스트 통과
  - `LibvirtComputingResourceTest#testGetVmStatsCommand`
  - `LibvirtComputingResourceTest` 전체 269개 테스트
- origin 브랜치 GitHub Actions 통과
  - Build: 성공
  - UI Build: 성공
  - License Check: 성공
  - PR Merge Conflict Check: 성공

## 관련 GitHub Actions

- Build: https://github.com/dhslove/ablestack-cloud/actions/runs/26400276986
- UI Build: https://github.com/dhslove/ablestack-cloud/actions/runs/26400276946
- License Check: https://github.com/dhslove/ablestack-cloud/actions/runs/26400276910
- PR Merge Conflict Check: https://github.com/dhslove/ablestack-cloud/actions/runs/26400276952
