### PR TITLE
N2K Cloud cutover 전원 정책 및 MAC 보존 UI 연동

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportUnmanagedInstanceForAblestackN2KCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ImportUnmanagedInstanceForAblestackN2KCmd.java
@@ -75,6 +75,11 @@ public class ImportUnmanagedInstanceForAblestackN2KCmd extends ImportVmCmd {
             description = "source snapshot/recovery point retention time in seconds for ablestack-n2k. Default is 1209600 seconds (14 days)")
     private Long retentionSeconds;
 
+    @Parameter(name = "starttargetvm",
+            type = CommandType.BOOLEAN,
+            description = "start the imported Cloud target VM after ablestack-n2k phase2 cutover. Default is true")
+    private Boolean startTargetVm;
+
     public String getSplitMode() {
         return StringUtils.defaultIfBlank(splitMode, DEFAULT_SPLIT_MODE);
     }
@@ -101,6 +106,14 @@ public class ImportUnmanagedInstanceForAblestackN2KCmd extends ImportVmCmd {
 
     public long getRetentionSeconds() {
         return retentionSeconds != null ? retentionSeconds : DEFAULT_RETENTION_SECONDS;
+    }
+
+    public Boolean getRequestedStartTargetVm() {
+        return startTargetVm;
+    }
+
+    public boolean isStartTargetVm() {
+        return BooleanUtils.toBooleanDefaultIfNull(startTargetVm, true);
     }
 
     @Override

--- a/core/src/main/java/com/cloud/agent/api/AblestackN2KConvertInstanceCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/AblestackN2KConvertInstanceCommand.java
@@ -51,6 +51,7 @@ public class AblestackN2KConvertInstanceCommand extends Command {
     private String cloudDisplayName;
     private String cloudCpuSpeed;
     private Long retentionSeconds;
+    private boolean startTargetVm = true;
     private boolean resume;
 
     public AblestackN2KConvertInstanceCommand() {
@@ -280,6 +281,14 @@ public class AblestackN2KConvertInstanceCommand extends Command {
 
     public void setRetentionSeconds(Long retentionSeconds) {
         this.retentionSeconds = retentionSeconds;
+    }
+
+    public boolean isStartTargetVm() {
+        return startTargetVm;
+    }
+
+    public void setStartTargetVm(boolean startTargetVm) {
+        this.startTargetVm = startTargetVm;
     }
 
     public boolean isResume() {

--- a/docs/ablestack_n2k_cloud_cutover_start_policy_design.md
+++ b/docs/ablestack_n2k_cloud_cutover_start_policy_design.md
@@ -1,3 +1,22 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 # ABLESTACK-N2K Cloud Cutover Start Policy Design
 
 ## 배경

--- a/docs/ablestack_n2k_cloud_cutover_start_policy_design.md
+++ b/docs/ablestack_n2k_cloud_cutover_start_policy_design.md
@@ -1,0 +1,34 @@
+# ABLESTACK-N2K Cloud Cutover Start Policy Design
+
+## 배경
+
+`ablestack_n2k wizard --apply` 또는 `ablestack_n2k run --apply`는 Cloud 대상 VM을 생성하되 시작하지 않는다. 반면 Cloud UI/API를 통해 실행하는 N2K 경로는 KVM agent wrapper가 항상 `--start`를 추가했기 때문에, 사용자가 cutover까지 완료한 뒤 대상 VM을 정지 상태로 남기는 정책을 선택할 수 없었다.
+
+## 설계
+
+### API
+
+`importUnmanagedInstanceForAblestackN2K`에 `starttargetvm` Boolean 파라미터를 추가한다. 기본값은 기존 동작과 동일하게 `true`이다.
+
+- `true`: Phase2 cutover 이후 Cloud 대상 VM을 시작한다. wrapper는 `--start`를 전달한다.
+- `false`: Phase2 cutover 이후 Cloud 대상 VM을 정지 상태로 둔다. wrapper는 `--apply`만 전달한다.
+
+### 작업 컨텍스트
+
+Phase1에서 선택한 정책은 import VM task의 source context JSON에 `startTargetVm`으로 저장한다. Phase2, resume, retry 요청에서 `starttargetvm`이 명시되지 않으면 저장된 값을 재사용한다. 저장값도 없으면 하위 호환을 위해 `true`로 처리한다.
+
+### Agent wrapper
+
+Cloud target provider(`ablestack-cloud`)인 경우 기존의 무조건 `--start` 호출을 `cmd.isStartTargetVm()`에 따라 분기한다. CLI/wizard의 기존 `--apply`/`--start` 의미는 변경하지 않는다.
+
+### UI
+
+초기 가져오기 대화상자의 N2K 섹션에 대상 VM 시작 여부 스위치를 추가한다. 기본값은 시작이다. Phase2 실행 모달에는 기존 설정 유지, 시작, 정지 유지 중 선택할 수 있는 드롭다운을 제공한다. 기본값은 기존 설정 유지로 두어 Phase1에서 저장한 정책을 보존한다.
+
+## 빌드/배포
+
+Cloud는 릴리즈 빌드가 아니라 Maven module 빌드와 UI module 빌드만 수행한다. 22번 공유 개발 환경에는 변경된 management/backend jar, agent jar, UI 정적 파일만 반영한다.
+
+## DB 변경
+
+신규 테이블/칼럼은 없다. 기존 import VM task source context JSON에 `startTargetVm` 키만 추가로 저장한다.

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtAblestackN2KConvertInstanceCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtAblestackN2KConvertInstanceCommandWrapper.java
@@ -150,7 +150,7 @@ public class LibvirtAblestackN2KConvertInstanceCommandWrapper extends CommandWra
                 script.add("--target-map-json", cmd.getTargetMapJson());
             }
             if (StringUtils.equals(targetProvider, CLOUD_TARGET_PROVIDER)) {
-                script.add("--start");
+                script.add(cmd.isStartTargetVm() ? "--start" : "--apply");
                 script.add("--cloud-cred-file", cloudCredentialFile.toString());
                 addIfNotBlank(script, "--cloud-zone-id", cmd.getCloudZoneId());
                 addIfNotBlank(script, "--cloud-service-offering-id", cmd.getCloudServiceOfferingId());

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtAblestackN2KConvertInstanceCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtAblestackN2KConvertInstanceCommandWrapperTest.java
@@ -122,12 +122,32 @@ public class LibvirtAblestackN2KConvertInstanceCommandWrapperTest {
             Mockito.verify(script).add("--cleanup-source-points");
             Mockito.verify(script).add("--target-map-json", "{\"scsi0:0\":\"rbd:rbd/rhel-disk0\"}");
             Mockito.verify(script).add("--start");
+            Mockito.verify(script, Mockito.never()).add("--apply");
             Mockito.verify(script).add(Mockito.eq("--cloud-cred-file"), Mockito.anyString());
             Mockito.verify(script).add("--cloud-zone-id", "zone-uuid");
             Mockito.verify(script).add("--cloud-service-offering-id", "service-offering-uuid");
             Mockito.verify(script).add("--cloud-network-ids", "network-uuid");
             Mockito.verify(script).add("--cloud-storage-id", "storage-uuid");
             Mockito.verify(script, Mockito.never()).add(Mockito.contains("secret"));
+        }
+    }
+
+    @Test
+    public void executeUsesApplyWithoutStartWhenCloudTargetVmShouldRemainStopped() throws IOException {
+        String workdir = temporaryFolder.newFolder("rhel-stopped").getAbsolutePath();
+        AblestackN2KConvertInstanceCommand cmd = validCommand(workdir);
+        cmd.setStartTargetVm(false);
+
+        try (MockedConstruction<Script> ignored = Mockito.mockConstruction(Script.class, (mock, context) -> {
+            Mockito.when(mock.execute(Mockito.any(OutputInterpreter.class))).thenReturn("");
+            Mockito.when(mock.getExitValue()).thenReturn(0);
+        })) {
+            Answer answer = wrapper.execute(cmd, libvirtComputingResource);
+
+            Assert.assertTrue(answer.getResult());
+            Script script = ignored.constructed().get(0);
+            Mockito.verify(script).add("--apply");
+            Mockito.verify(script, Mockito.never()).add("--start");
         }
     }
 

--- a/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/UnmanagedVMsManagerImpl.java
@@ -4776,8 +4776,10 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             Map<String, String> sourceContext = new LinkedHashMap<>();
             sourceContext.put("sourceApi", cmd.getSourceApi());
             sourceContext.put("resolvedSourceApi", inventory.getSourceApi());
+            boolean startTargetVm = getAblestackN2KStartTargetVm(cmd, sourceContext);
             sourceContext.put("insecure", Boolean.toString(cmd.isInsecure()));
             sourceContext.put("retentionSeconds", Long.toString(retentionSeconds));
+            sourceContext.put("startTargetVm", Boolean.toString(startTargetVm));
             importVmTasksManager.updateImportVMTaskN2KContext(importVMTask, destinationCluster.getId(), serviceOffering.getId(),
                     targetStoragePool.getId(), cmd.getHost(), cmd.getSourceApi(), gson.toJson(sourceNutanixInstance),
                     serviceOfferingDetails, buildNicSelectionMap(nicNetworkMap, nicIpAddressMap), targetStoragePlan.getTargetProfile(),
@@ -4787,7 +4789,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             startNutanixInstanceToKVMUsingAblestackN2K(sourceVMName, convertHost, targetStorageLocation, cmd.getHost(),
                     cmd.getUsername(), cmd.getPassword(), cmd.getSplitMode(), cmd.getSourceApi(), cmd.isInsecure(), workdir,
                     nfsHost, targetStoragePlan, persistedImportTask, zone, owner, serviceOffering, targetStoragePool, nicNetworkMap,
-                    hostName, displayName, retentionSeconds);
+                    hostName, displayName, retentionSeconds, false, startTargetVm);
             if (StringUtils.equalsIgnoreCase(cmd.getSplitMode(), "full")) {
                 AblestackN2KStatusAnswer status = refreshImportVMTaskWithAblestackN2KStatus(persistedImportTask, convertHost);
                 importVmTasksManager.updateImportVMTaskV2KStep(persistedImportTask, ImportVmTask.V2KStep.Phase2_Completed);
@@ -4830,7 +4832,9 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         String targetVmName = StringUtils.defaultIfBlank(task.getTargetVMName(), task.getDisplayName());
         Map<String, String> sourceContext = getTaskSourceContextMap(task);
         long retentionSeconds = getAblestackN2KRetentionSeconds(cmd, sourceContext);
+        boolean startTargetVm = getAblestackN2KStartTargetVm(cmd, sourceContext);
         sourceContext.put("retentionSeconds", Long.toString(retentionSeconds));
+        sourceContext.put("startTargetVm", Boolean.toString(startTargetVm));
 
         ImportVmTaskSourceCredential storedCredential = importVmTasksManager.getImportVMTaskSourceCredential(task);
         String prismEndpoint = StringUtils.defaultIfBlank(cmd.getHost(), task.getSourceEndpoint());
@@ -4860,7 +4864,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             startNutanixInstanceToKVMUsingAblestackN2K(task.getSourceVMName(), convertHost, targetStorageLocation,
                     prismEndpoint, username, password, "phase2", "v3", cmd.isInsecure(), task.getWorkdir(), nfsHost,
                     targetStoragePlan, task, zone, owner, serviceOffering, targetStoragePool, nicNetworkMap, targetVmName, targetVmName,
-                    retentionSeconds);
+                    retentionSeconds, false, startTargetVm);
             triggerAblestackN2KPhase2MonitoringInBackground(task.getUuid());
         } catch (RuntimeException e) {
             logger.error(String.format("Error while executing ablestack-n2k phase2 workflow for task %s", task.getUuid()), e);
@@ -4974,6 +4978,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         String sourceApi = StringUtils.defaultIfBlank(cmd.getSourceApi(), StringUtils.defaultIfBlank(sourceContext.get("sourceApi"), "v3"));
         boolean insecure = cmd.isInsecure();
         long retentionSeconds = getAblestackN2KRetentionSeconds(cmd, sourceContext);
+        boolean startTargetVm = getAblestackN2KStartTargetVm(cmd, sourceContext);
 
         try {
             if (!resume) {
@@ -4992,6 +4997,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             }
             sourceContext.put("insecure", Boolean.toString(insecure));
             sourceContext.put("retentionSeconds", Long.toString(retentionSeconds));
+            sourceContext.put("startTargetVm", Boolean.toString(startTargetVm));
             importVmTasksManager.updateImportVMTaskN2KContext(task, task.getClusterId(), task.getServiceOfferingId(),
                     targetStoragePool.getId(), prismEndpoint, sourceApi, gson.toJson(sourceInstance),
                     getTaskServiceOfferingDetails(task), getTaskNicSelectionMap(task), targetStoragePlan.getTargetProfile(),
@@ -5006,7 +5012,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
             startNutanixInstanceToKVMUsingAblestackN2K(task.getSourceVMName(), convertHost, targetStorageLocation,
                     prismEndpoint, username, password, splitMode, sourceApi, insecure, workdir, nfsHost,
                     targetStoragePlan, task, zone, owner, serviceOffering, targetStoragePool, nicNetworkMap, targetVmName, targetVmName,
-                    retentionSeconds, resume);
+                    retentionSeconds, resume, startTargetVm);
             if (StringUtils.equalsIgnoreCase(splitMode, "phase2")) {
                 triggerAblestackN2KPhase2MonitoringInBackground(task.getUuid());
             }
@@ -5028,7 +5034,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                                                             Map<String, Long> nicNetworkMap, String hostName, String displayName) {
         startNutanixInstanceToKVMUsingAblestackN2K(sourceVM, convertHost, targetStorageLocation, prismEndpoint, username, password,
                 splitMode, sourceApi, insecure, workdir, nfsHost, targetStoragePlan, importTask, zone, owner,
-                serviceOffering, targetStoragePool, nicNetworkMap, hostName, displayName, ABLESTACK_N2K_DEFAULT_RETENTION_SECONDS, false);
+                serviceOffering, targetStoragePool, nicNetworkMap, hostName, displayName, ABLESTACK_N2K_DEFAULT_RETENTION_SECONDS, false, true);
     }
 
     private void startNutanixInstanceToKVMUsingAblestackN2K(String sourceVM, HostVO convertHost, DataStoreTO targetStorageLocation,
@@ -5041,7 +5047,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                                                             long retentionSeconds) {
         startNutanixInstanceToKVMUsingAblestackN2K(sourceVM, convertHost, targetStorageLocation, prismEndpoint, username, password,
                 splitMode, sourceApi, insecure, workdir, nfsHost, targetStoragePlan, importTask, zone, owner,
-                serviceOffering, targetStoragePool, nicNetworkMap, hostName, displayName, retentionSeconds, false);
+                serviceOffering, targetStoragePool, nicNetworkMap, hostName, displayName, retentionSeconds, false, true);
     }
 
     private void startNutanixInstanceToKVMUsingAblestackN2K(String sourceVM, HostVO convertHost, DataStoreTO targetStorageLocation,
@@ -5051,7 +5057,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
                                                             ImportVMTaskVO importTask, DataCenter zone, Account owner,
                                                             ServiceOfferingVO serviceOffering, StoragePoolVO targetStoragePool,
                                                             Map<String, Long> nicNetworkMap, String hostName, String displayName,
-                                                            long retentionSeconds, boolean resume) {
+                                                            long retentionSeconds, boolean resume, boolean startTargetVm) {
         logger.debug("Delegating the conversion of instance {} from Nutanix to KVM to the host {} using ablestack-n2k", sourceVM, convertHost);
 
         List<String> missingParams = new ArrayList<>();
@@ -5083,6 +5089,7 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         AblestackN2KConvertInstanceCommand cmd = new AblestackN2KConvertInstanceCommand(sourceVM, prismEndpoint, username, password,
                 targetStorageLocation, splitMode, sourceApi, insecure, workdir);
         cmd.setResume(resume);
+        cmd.setStartTargetVm(startTargetVm);
         cmd.setNfsHost(nfsHost);
         cmd.setRetentionSeconds(retentionSeconds);
         cmd.setTargetFormat(targetStoragePlan.getTargetFormat());
@@ -5538,6 +5545,20 @@ public class UnmanagedVMsManagerImpl implements UnmanagedVMsManager {
         }
 
         return ABLESTACK_N2K_DEFAULT_RETENTION_SECONDS;
+    }
+
+    protected boolean getAblestackN2KStartTargetVm(ImportUnmanagedInstanceForAblestackN2KCmd cmd, Map<String, String> sourceContext) {
+        Boolean requestedStartTargetVm = cmd != null ? cmd.getRequestedStartTargetVm() : null;
+        if (requestedStartTargetVm != null) {
+            return BooleanUtils.toBoolean(requestedStartTargetVm);
+        }
+
+        String storedStartTargetVm = sourceContext != null ? StringUtils.trimToNull(sourceContext.get("startTargetVm")) : null;
+        if (StringUtils.isNotBlank(storedStartTargetVm)) {
+            return BooleanUtils.toBoolean(storedStartTargetVm);
+        }
+
+        return true;
     }
 
     protected String getAblestackTaskResumeSplitMode(ImportVMTaskVO task) {

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -5575,5 +5575,10 @@
   "message.confirm.retry.import.vm.task.from.start": "Keep the existing task record and start a new import task from the beginning with the same selections.",
   "message.confirm.cancel.import.vm.task": "Cancel the running import task and try to cleanup temporary migration resources on the conversion host.",
   "message.confirm.delete.import.vm.task": "Delete the import task from the list. Stored credentials and temporary work directories are also cleaned up when selected.",
-  "message.confirm.clear.import.vm.task.credentials": "Delete the encrypted source credential stored for this task. You may need to enter credentials again for Phase2 or resume."
+  "message.confirm.clear.import.vm.task.credentials": "Delete the encrypted source credential stored for this task. You may need to enter credentials again for Phase2 or resume.",
+  "label.n2k.start.target.vm": "Start target VM after cutover",
+  "label.n2k.keep.target.vm.stopped": "Keep target VM stopped",
+  "label.n2k.target.vm.power.policy": "Target VM power policy",
+  "label.keep.current.setting": "Keep current setting",
+  "message.n2k.start.target.vm": "When enabled, Phase2 starts the imported Cloud VM after cutover. Disable it to leave the target VM stopped after import."
 }

--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -5564,6 +5564,7 @@
   "message.skip.tls.verify.nutanix": "Allow connections to Nutanix Prism endpoints that use self-signed certificates.",
   "message.nutanix.prism.endpoint.tooltip": "Enter the Nutanix Prism Central or Prism Element endpoint, for example https://10.10.132.100:9440.",
   "message.select.ablestack.n2k.primary.storage.migration": "Select the ABLESTACK primary storage target for N2K migration. If no pool is selected, Cloud chooses a compatible default.",
+  "message.ablestack.n2k.preserve.source.mac": "During Phase2 cutover, the source VM is shut down and the first source NIC MAC address is preserved on the Cloud VM default NIC.",
   "message.n2k.snapshot.retention.days": "Nutanix recovery points used for phase split migration are retained for this period. Default is 14 days.",
   "message.select.kvm.host.ablestack.import": "Select the ABLESTACK host that will run the import worker.",
   "message.select.primary.storage.ablestack.import": "Select the target primary storage for the imported VM disks.",

--- a/ui/public/locales/ko_KR.json
+++ b/ui/public/locales/ko_KR.json
@@ -5575,5 +5575,10 @@
   "message.confirm.retry.import.vm.task.from.start": "기존 작업은 보존하고 동일한 조건으로 새 가져오기 작업을 처음부터 다시 시작합니다.",
   "message.confirm.cancel.import.vm.task": "진행 중인 가져오기 작업을 취소하고 변환 호스트의 임시 작업 리소스 정리를 시도합니다.",
   "message.confirm.delete.import.vm.task": "가져오기 작업 기록을 목록에서 삭제합니다. 선택한 경우 저장된 Credential과 임시 작업 디렉터리도 함께 정리됩니다.",
-  "message.confirm.clear.import.vm.task.credentials": "이 작업에 저장된 암호화 소스 Credential을 삭제합니다. 삭제 후 Phase2 또는 재개 시 Credential을 다시 입력해야 할 수 있습니다."
+  "message.confirm.clear.import.vm.task.credentials": "이 작업에 저장된 암호화 소스 Credential을 삭제합니다. 삭제 후 Phase2 또는 재개 시 Credential을 다시 입력해야 할 수 있습니다.",
+  "label.n2k.start.target.vm": "Cutover 후 대상 VM 시작",
+  "label.n2k.keep.target.vm.stopped": "대상 VM 정지 상태 유지",
+  "label.n2k.target.vm.power.policy": "대상 VM 전원 정책",
+  "label.keep.current.setting": "기존 설정 유지",
+  "message.n2k.start.target.vm": "활성화하면 Phase2 cutover 후 가져온 Cloud VM을 시작합니다. 비활성화하면 가져오기 완료 후 대상 VM을 정지 상태로 유지합니다."
 }

--- a/ui/public/locales/ko_KR.json
+++ b/ui/public/locales/ko_KR.json
@@ -5564,6 +5564,7 @@
   "message.skip.tls.verify.nutanix": "자체 서명 인증서를 사용하는 Nutanix Prism 엔드포인트 접속을 허용합니다.",
   "message.nutanix.prism.endpoint.tooltip": "Nutanix Prism Central 또는 Prism Element 엔드포인트를 입력합니다. 예: https://10.10.132.100:9440",
   "message.select.ablestack.n2k.primary.storage.migration": "N2K 마이그레이션에 사용할 ABLESTACK 기본 스토리지 대상을 선택합니다. 풀을 선택하지 않으면 Cloud가 호환 가능한 기본값을 선택합니다.",
+  "message.ablestack.n2k.preserve.source.mac": "Phase2 cutover에서 원본 VM을 종료한 뒤 첫 번째 NIC의 MAC 주소를 Cloud VM 기본 NIC에 유지해 배포합니다.",
   "message.n2k.snapshot.retention.days": "Phase 분리 이관에 사용하는 Nutanix Recovery Point를 지정한 기간 동안 보존합니다. 기본값은 14일입니다.",
   "message.select.kvm.host.ablestack.import": "Import 작업자를 실행할 ABLESTACK 호스트를 선택합니다.",
   "message.select.primary.storage.ablestack.import": "가져온 VM 디스크를 배치할 대상 기본 스토리지를 선택합니다.",

--- a/ui/src/views/tools/ImportUnmanagedInstance.vue
+++ b/ui/src/views/tools/ImportUnmanagedInstance.vue
@@ -193,6 +193,14 @@
                 :showIcon="true"
                 :message="$t('label.ablestack.n2k.use')"
                 :description="$t('message.select.ablestack.n2k.primary.storage.migration')" />
+              <a-form-item v-if="isAblestackN2KImport" name="starttargetvm" ref="starttargetvm">
+                <template #label>
+                  <tooltip-label
+                    :title="$t('label.n2k.start.target.vm')"
+                    :tooltip="$t('message.n2k.start.target.vm')" />
+                </template>
+                <a-switch v-model:checked="form.starttargetvm" />
+              </a-form-item>
               <a-form-item v-if="isAblestackN2KImport" name="n2kretentiondays" ref="n2kretentiondays">
                 <template #label>
                   <tooltip-label
@@ -1044,6 +1052,7 @@ export default {
         forcemstoimportvmfiles: this.switches.forceMsToImportVmFiles,
         forceconverttopool: this.switches.forceConvertToPool,
         useablestackv2k: this.defaultUseAblestackV2K(),
+        starttargetvm: true,
         n2kretentiondays: 14,
         domainid: null,
         account: null,
@@ -1723,6 +1732,7 @@ export default {
             return
           }
           params.retentionseconds = Math.round(retentionDays * 24 * 60 * 60)
+          params.starttargetvm = values.starttargetvm !== false
           if (this.selectedKvmHostForConversion) {
             params.convertinstancehostid = this.selectedKvmHostForConversion
           }
@@ -1877,6 +1887,7 @@ export default {
       this.form.usevddk = false
       this.form.forceconverttopool = false
       this.form.forcemstoimportvmfiles = false
+      this.form.starttargetvm = true
       this.form.n2kretentiondays = 14
       this.userModifiedVddkSetting = false
       this.selectedKvmHostForConversion = null

--- a/ui/src/views/tools/ImportUnmanagedInstance.vue
+++ b/ui/src/views/tools/ImportUnmanagedInstance.vue
@@ -474,6 +474,12 @@
                   </template>
                   <span>{{ $t('message.ip.address.changes.effect.after.vm.restart') }}</span>
                 </a-form-item>
+                <a-alert
+                  v-if="isAblestackN2KImport && resource.nic && resource.nic.length > 0"
+                  class="import-form-alert ablestack-import-alert"
+                  type="info"
+                  :showIcon="true"
+                  :message="$t('message.ablestack.n2k.preserve.source.mac')" />
                 <a-row v-if="selectedVmwareVcenter" :gutter="12" justify="end">
                   <a-col style="text-align: right">
                     <a-form-item name="forced" ref="forced">

--- a/ui/src/views/tools/ImportVmTasks.vue
+++ b/ui/src/views/tools/ImportVmTasks.vue
@@ -239,6 +239,13 @@
             <a-select-option value="v3">{{ $t('label.nutanix.api.v3') }}</a-select-option>
           </a-select>
         </a-form-item>
+        <a-form-item v-if="isN2KTask(phase2Task)" :label="$t('label.n2k.target.vm.power.policy')">
+          <a-select v-model:value="phase2Form.starttargetvm">
+            <a-select-option :value="null">{{ $t('label.keep.current.setting') }}</a-select-option>
+            <a-select-option :value="true">{{ $t('label.n2k.start.target.vm') }}</a-select-option>
+            <a-select-option :value="false">{{ $t('label.n2k.keep.target.vm.stopped') }}</a-select-option>
+          </a-select>
+        </a-form-item>
         <a-form-item v-if="isN2KTask(phase2Task)" :label="$t('label.n2k.snapshot.retention.days')">
           <a-input-number
             v-model:value="phase2Form.retentiondays"
@@ -400,6 +407,7 @@ export default {
         username: '',
         password: '',
         sourceapi: 'v3',
+        starttargetvm: null,
         insecure: true,
         retentiondays: 14
       },
@@ -452,6 +460,7 @@ export default {
         username: '',
         password: '',
         sourceapi: 'v3',
+        starttargetvm: null,
         insecure: true,
         retentiondays: 14
       }
@@ -464,6 +473,9 @@ export default {
       if (this.phase2Form.password) credential.password = this.phase2Form.password
       if (this.isN2KTask(this.phase2Task)) {
         credential.sourceapi = 'v3'
+        if (this.phase2Form.starttargetvm !== null && this.phase2Form.starttargetvm !== undefined) {
+          credential.starttargetvm = this.phase2Form.starttargetvm
+        }
         credential.insecure = this.phase2Form.insecure !== false
         const retentionDays = Number(this.phase2Form.retentiondays || 14)
         if (!Number.isFinite(retentionDays) || retentionDays < 1) {

--- a/ui/src/views/tools/ManageInstances.vue
+++ b/ui/src/views/tools/ManageInstances.vue
@@ -1422,6 +1422,9 @@ export default {
       if (credential.retentionseconds) {
         params.retentionseconds = credential.retentionseconds
       }
+      if (credential.starttargetvm !== undefined) {
+        params.starttargetvm = credential.starttargetvm
+      }
       if (!isN2KTask && this.selectedVmwareVcenter) {
         if (this.selectedVmwareVcenter.existingvcenterid) {
           params.existingvcenterid = this.selectedVmwareVcenter.existingvcenterid


### PR DESCRIPTION
## 개요

N2K 기반 Nutanix VM 가져오기에서 Cloud 관점의 cutover 동작을 보완합니다. 원본 MAC 주소 보존 흐름을 UI에 명확히 표시하고, Phase2 cutover 이후 대상 VM을 자동 시작할지 또는 정지 상태로 유지할지 선택할 수 있도록 API, Backend, KVM wrapper, UI를 연결했습니다.

## 주요 변경 사항

- `importUnmanagedInstanceForAblestackN2K` API에 `starttargetvm` 파라미터를 추가했습니다.
- 신규 N2K 가져오기 등록 시 기본값은 기존 동작과 동일하게 대상 VM 자동 시작입니다.
- Phase2 실행 모달에서 대상 VM 전원 정책을 선택할 수 있도록 했습니다.
  - 기존 설정 유지
  - 대상 VM 시작
  - 대상 VM 정지 유지
- Backend에서 `startTargetVm` 값을 task source context에 저장하고, retry/resume/phase2 실행 시 재사용하도록 했습니다.
- KVM wrapper에서 `startTargetVm=true`는 `--start`, `false`는 `--apply`로 전달하도록 했습니다.
- N2K import dialog에 원본 NIC MAC 주소 보존 안내를 추가했습니다.
- 관련 한글/영문 i18n 문구를 추가했습니다.
- KVM wrapper 단위 테스트에 `--start` / `--apply` 전달 검증을 추가했습니다.
- 설계 문서를 추가했습니다.

## DB 변경

- DB 스키마 변경 없음.
- 신규 테이블/컬럼 추가 없음.
- `import_vm_task` 계열의 기존 source context JSON에 `startTargetVm` 값을 저장해 재사용합니다.
- 따라서 별도 DB migration은 필요하지 않습니다.

## 검증

- Maven module build:
  - `mvn -pl api,core,server,plugins/hypervisors/kvm -am -DskipTests install`
- KVM wrapper test:
  - `mvn -pl plugins/hypervisors/kvm -Dtest=LibvirtAblestackN2KConvertInstanceCommandWrapperTest test`
- UI build:
  - `npm run build`
- 22.x 테스트 환경 반영 후 `mold-agent.service` 정상 기동 및 관리 서버 ReadyAnswer/host stats 수신을 확인했습니다.

## 배포 주의 사항

22.x 공유 개발 환경에서는 새 브랜치에서 빌드한 전체 `cloud-core` 또는 KVM plugin jar를 그대로 덮어쓰지 않아야 합니다. 현재 호스트 런타임과 다른 신규 의존성이 포함될 수 있으므로, 호스트에 배포된 기존 jar 백업본을 기준으로 필요한 변경 클래스만 패치하거나, 전체 런타임 정합 패키지를 명시적으로 승인받고 반영해야 합니다.