### PR TITLE
VolumeStatsTask NPE 방지

### DIFF
--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -1929,12 +1929,28 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                         continue;
                     }
                     List<VolumeVO> volumes = _volsDao.findNonDestroyedVolumesByPoolId(pool.getId(), null);
+                    if (CollectionUtils.isEmpty(volumes)) {
+                        continue;
+                    }
+                    boolean unsupportedVolumeFormat = false;
                     for (VolumeVO volume : volumes) {
-                        if (!List.of(ImageFormat.QCOW2, ImageFormat.VHD, ImageFormat.OVA, ImageFormat.RAW).contains(volume.getFormat()) &&
-                            !List.of(Storage.StoragePoolType.PowerFlex, Storage.StoragePoolType.FiberChannel).contains(pool.getPoolType())) {
-                            logger.warn("Volume stats not implemented for this format type " + volume.getFormat());
+                        ImageFormat volumeFormat = volume.getFormat();
+                        Storage.StoragePoolType poolType = pool.getPoolType();
+                        boolean poolTypeSupportsVolumeStats = poolType != null && List.of(Storage.StoragePoolType.PowerFlex, Storage.StoragePoolType.FiberChannel).contains(poolType);
+                        boolean volumeFormatSupportsVolumeStats = volumeFormat != null && List.of(ImageFormat.QCOW2, ImageFormat.VHD, ImageFormat.OVA, ImageFormat.RAW).contains(volumeFormat);
+                        if (volumeFormat == null && !poolTypeSupportsVolumeStats) {
+                            logger.debug("Skipping volume stats for volume {} on storage pool {} as volume format is unavailable", volume.getUuid(), pool.getUuid());
+                            unsupportedVolumeFormat = true;
                             break;
                         }
+                        if (!volumeFormatSupportsVolumeStats && !poolTypeSupportsVolumeStats) {
+                            logger.warn("Volume stats not implemented for this format type " + volumeFormat);
+                            unsupportedVolumeFormat = true;
+                            break;
+                        }
+                    }
+                    if (unsupportedVolumeFormat) {
+                        continue;
                     }
                     try {
                         Map<String, VolumeStatsEntry> volumeStatsByUuid;
@@ -1947,7 +1963,12 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                                 }
                             }
                         } else {
-                            volumeStatsByUuid = _userVmMgr.getVolumeStatistics(pool.getClusterId(), pool.getUuid(), pool.getPoolType(), StatsTimeout.value());
+                            Long clusterId = pool.getClusterId();
+                            if (clusterId == null) {
+                                logger.debug("Skipping volume stats for storage pool {} as scope {} has no cluster id", pool.getUuid(), pool.getScope());
+                                continue;
+                            }
+                            volumeStatsByUuid = _userVmMgr.getVolumeStatistics(clusterId, pool.getUuid(), pool.getPoolType(), StatsTimeout.value());
                         }
                         if (volumeStatsByUuid != null) {
                             for (final Map.Entry<String, VolumeStatsEntry> entry : volumeStatsByUuid.entrySet()) {

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -2431,8 +2431,16 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
     @Override
     public HashMap<String, VolumeStatsEntry> getVolumeStatistics(long clusterId, String poolUuid, StoragePoolType poolType,  int timeout) {
-        List<HostVO> neighbors = _resourceMgr.listHostsInClusterByStatus(clusterId, Status.Up);
         StoragePoolVO storagePool = _storagePoolDao.findPoolByUUID(poolUuid);
+        if (storagePool == null) {
+            logger.debug("Unable to collect volume stats as storage pool {} was not found", poolUuid);
+            return null;
+        }
+        List<HostVO> neighbors = _resourceMgr.listHostsInClusterByStatus(clusterId, Status.Up);
+        if (CollectionUtils.isEmpty(neighbors)) {
+            logger.debug("Unable to collect volume stats for storage pool {} as cluster {} has no Up hosts", poolUuid, clusterId);
+            return null;
+        }
         HashMap<String, VolumeStatsEntry> volumeStatsByUuid = new HashMap<>();
 
         for (HostVO neighbor : neighbors) {
@@ -2451,7 +2459,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
                 DataStoreProvider storeProvider = _dataStoreProviderMgr
                         .getDataStoreProvider(storagePool.getStorageProviderName());
-                DataStoreDriver storeDriver = storeProvider.getDataStoreDriver();
+                DataStoreDriver storeDriver = storeProvider != null ? storeProvider.getDataStoreDriver() : null;
 
                 if (storeDriver instanceof PrimaryDataStoreDriver && ((PrimaryDataStoreDriver) storeDriver).canProvideVolumeStats()) {
                     // Get volume stats from the pool directly instead of sending cmd to host

--- a/server/src/test/java/com/cloud/server/StatsCollectorTest.java
+++ b/server/src/test/java/com/cloud/server/StatsCollectorTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import com.cloud.utils.DateUtil;
 import com.google.gson.JsonSyntaxException;
 import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.commons.collections.CollectionUtils;
 import org.influxdb.InfluxDB;
@@ -66,11 +67,16 @@ import com.cloud.agent.api.VmDiskStatsEntry;
 import com.cloud.agent.api.VmStatsEntry;
 import com.cloud.hypervisor.Hypervisor;
 import com.cloud.server.StatsCollector.ExternalStatsProtocol;
+import com.cloud.storage.ScopeType;
+import com.cloud.storage.Storage;
 import com.cloud.storage.StorageStats;
 import com.cloud.storage.VolumeStatsVO;
+import com.cloud.storage.VolumeVO;
+import com.cloud.storage.dao.VolumeDao;
 import com.cloud.storage.dao.VolumeStatsDao;
 import com.cloud.user.VmDiskStatisticsVO;
 import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.vm.UserVmManager;
 import com.cloud.vm.VmStats;
 import com.cloud.vm.VmStatsVO;
 import com.cloud.vm.dao.VmStatsDaoImpl;
@@ -116,6 +122,15 @@ public class StatsCollectorTest {
     VolumeStatsDao volumeStatsDao = Mockito.mock(VolumeStatsDao.class);
 
     @Mock
+    PrimaryDataStoreDao storagePoolDao = Mockito.mock(PrimaryDataStoreDao.class);
+
+    @Mock
+    VolumeDao volumeDao = Mockito.mock(VolumeDao.class);
+
+    @Mock
+    UserVmManager userVmManager = Mockito.mock(UserVmManager.class);
+
+    @Mock
     private StoragePoolVO mockPool;
 
     private static Gson gson = new Gson();
@@ -131,6 +146,9 @@ public class StatsCollectorTest {
         closeable = MockitoAnnotations.openMocks(this);
         statsCollector.vmStatsDao = vmStatsDaoMock;
         statsCollector.volumeStatsDao = volumeStatsDao;
+        ReflectionTestUtils.setField(statsCollector, "_storagePoolDao", storagePoolDao);
+        ReflectionTestUtils.setField(statsCollector, "_volsDao", volumeDao);
+        ReflectionTestUtils.setField(statsCollector, "_userVmMgr", userVmManager);
         Field msStatsGsonField = StatsCollector.class.getDeclaredField("msStatsGson");
         msStatsGsonField.setAccessible(true);
         msStatsGson = (Gson) msStatsGsonField.get(null);
@@ -620,6 +638,61 @@ public class StatsCollectorTest {
         Assert.assertFalse(result);
         Mockito.verify(mockPool, Mockito.never()).setCapacityIops(Mockito.anyLong());
         Mockito.verify(mockPool, Mockito.never()).setUsedIops(Mockito.anyLong());
+    }
+
+    @Test
+    public void volumeStatsTaskSkipsEmptyPools() {
+        configureStoragePool(1L, "pool-uuid", ScopeType.CLUSTER, 1L, Storage.StoragePoolType.NetworkFilesystem);
+        when(volumeDao.findNonDestroyedVolumesByPoolId(1L, null)).thenReturn(new ArrayList<>());
+
+        statsCollector.new VolumeStatsTask().runInContext();
+
+        Mockito.verify(userVmManager, Mockito.never()).getVolumeStatistics(Mockito.anyLong(), Mockito.anyString(), Mockito.any(), Mockito.anyInt());
+    }
+
+    @Test
+    public void volumeStatsTaskSkipsNonZonePoolsWithoutClusterId() {
+        configureStoragePool(1L, "pool-uuid", ScopeType.CLUSTER, null, Storage.StoragePoolType.NetworkFilesystem);
+        VolumeVO volume = Mockito.mock(VolumeVO.class);
+        when(volume.getFormat()).thenReturn(Storage.ImageFormat.QCOW2);
+        when(volumeDao.findNonDestroyedVolumesByPoolId(1L, null)).thenReturn(Arrays.asList(volume));
+
+        statsCollector.new VolumeStatsTask().runInContext();
+
+        Mockito.verify(userVmManager, Mockito.never()).getVolumeStatistics(Mockito.anyLong(), Mockito.anyString(), Mockito.any(), Mockito.anyInt());
+    }
+
+    @Test
+    public void volumeStatsTaskSkipsVolumesWithoutFormat() {
+        configureStoragePool(1L, "pool-uuid", ScopeType.CLUSTER, 1L, Storage.StoragePoolType.NetworkFilesystem);
+        VolumeVO volume = Mockito.mock(VolumeVO.class);
+        when(volume.getFormat()).thenReturn(null);
+        when(volumeDao.findNonDestroyedVolumesByPoolId(1L, null)).thenReturn(Arrays.asList(volume));
+
+        statsCollector.new VolumeStatsTask().runInContext();
+
+        Mockito.verify(userVmManager, Mockito.never()).getVolumeStatistics(Mockito.anyLong(), Mockito.anyString(), Mockito.any(), Mockito.anyInt());
+    }
+
+    @Test
+    public void volumeStatsTaskSkipsVolumesWithoutPoolType() {
+        configureStoragePool(1L, "pool-uuid", ScopeType.CLUSTER, 1L, null);
+        VolumeVO volume = Mockito.mock(VolumeVO.class);
+        when(volume.getFormat()).thenReturn(null);
+        when(volumeDao.findNonDestroyedVolumesByPoolId(1L, null)).thenReturn(Arrays.asList(volume));
+
+        statsCollector.new VolumeStatsTask().runInContext();
+
+        Mockito.verify(userVmManager, Mockito.never()).getVolumeStatistics(Mockito.anyLong(), Mockito.anyString(), Mockito.any(), Mockito.anyInt());
+    }
+
+    private void configureStoragePool(long poolId, String uuid, ScopeType scope, Long clusterId, Storage.StoragePoolType poolType) {
+        when(storagePoolDao.listAll()).thenReturn(Arrays.asList(mockPool));
+        when(mockPool.getId()).thenReturn(poolId);
+        when(mockPool.getUuid()).thenReturn(uuid);
+        when(mockPool.getScope()).thenReturn(scope);
+        when(mockPool.getClusterId()).thenReturn(clusterId);
+        when(mockPool.getPoolType()).thenReturn(poolType);
     }
 
     @Test


### PR DESCRIPTION
## 요약

- `VolumeStatsTask`가 볼륨 통계 수집 중 `volume.getFormat()` 또는 pool 메타데이터가 비어 있는 경우 `NullPointerException`을 반복 출력하지 않도록 보강했습니다.
- 볼륨 format이 없는 경우에는 volume stats 수집을 debug 수준으로 skip하고, 실제 미지원 format만 기존처럼 warn으로 남기도록 정리했습니다.
- `UserVmManagerImpl#getVolumeStatistics`에서도 storage pool, Up host, provider 조회 결과가 비어 있는 경합 상황을 null-safe하게 처리했습니다.

## 확인한 현상

- 22.10 관리서버 로그에서 `VolumeStatsTask`가 약 10분 주기로 `java.util.ImmutableCollections$ListN.indexOf` 경유 NPE를 반복했습니다.
- 원인은 `List.of(...).contains(null)` 호출이며, 실제 로그의 스택은 `StatsCollector$VolumeStatsTask.runInContext`에서 발생했습니다.

## 검증

- `mvn -pl server -Dtest=StatsCollectorTest test -DskipSurefireReport`
- `mvn -pl server -DskipTests package`
- 22.10 관리서버에 변경 class hot patch 후 `ServerDaemon` 재시작 및 API alive 확인
- 최종 배포 후 `VolumeStatsTask` NPE가 재발하지 않고 null format volume은 debug skip 로그로 처리됨을 확인

## 배포 메모

- 공유 22.x 환경에는 전체 jar 교체 대신 기존 배포 jar 백업 후 변경 class만 패치했습니다.
- `cloud-server-4.22.0.0-SNAPSHOT.jar`와 `cloudstack-4.22.0.0-SNAPSHOT.jar` 양쪽에 동일 class가 있어 두 jar 모두 패치가 필요했습니다.
