### PR TITLE
[Mold Diplo] 기본스토리지의 "kvm.ha.on.storage.heartbeat" 값 변경 시 호스트 에이전트의 재시작 없이 HA HB 대상 스토리지로 반영되도록 기능 개선

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KVMHAMonitor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KVMHAMonitor.java
@@ -119,6 +119,19 @@ public class KVMHAMonitor extends KVMHABase implements Runnable {
         }
     }
 
+    public void removeStoragePoolFromMonitoring(String uuid) {
+        removeStoragePoolFromMonitoring(storagePool, uuid);
+        removeStoragePoolFromMonitoring(storageGfsPool, uuid);
+        removeStoragePoolFromMonitoring(storageRbdPool, uuid);
+        removeStoragePoolFromMonitoring(storageClvmPool, uuid);
+    }
+
+    private void removeStoragePoolFromMonitoring(Map<String, HAStoragePool> storagePools, String uuid) {
+        synchronized (storagePools) {
+            storagePools.remove(uuid);
+        }
+    }
+
     public List<HAStoragePool> getStoragePools() {
         synchronized (storagePool) {
             return new ArrayList<>(storagePool.values());

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStoragePoolManager.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStoragePoolManager.java
@@ -52,6 +52,7 @@ import com.cloud.vm.VirtualMachine;
 
 public class KVMStoragePoolManager {
     protected Logger logger = LogManager.getLogger(getClass());
+    protected static final String KVM_HA_ON_STORAGE_HEARTBEAT = "kvm.ha.on.storage.heartbeat";
 
     private class StoragePoolInformation {
         String name;
@@ -392,27 +393,40 @@ public class KVMStoragePoolManager {
         StorageAdaptor adaptor = getStorageAdaptor(type);
         KVMStoragePool pool = adaptor.createStoragePool(name, host, port, path, userInfo, type, details, primaryStorage);
 
-        if (MapUtils.isNotEmpty(details) && details.containsKey("kvm.ha.on.storage.heartbeat") && "true".equals(details.get("kvm.ha.on.storage.heartbeat"))) {
-            // LibvirtStorageAdaptor-specific statement
-            if (type == StoragePoolType.NetworkFilesystem && primaryStorage) {
-                KVMHABase.HAStoragePool storagePool = new KVMHABase.HAStoragePool(pool, host, path, PoolType.PrimaryStorage);
-                _haMonitor.addStoragePool(storagePool);
-            } else if (type == StoragePoolType.SharedMountPoint && primaryStorage) {
-                KVMHABase.HAStoragePool gfsPool = new KVMHABase.HAStoragePool(pool, host, path, PoolType.PrimaryStorage);
-                _haMonitor.addGfsStoragePool(gfsPool);
-            } else if (type == StoragePoolType.RBD && primaryStorage) {
-                KVMHABase.HAStoragePool rbdPool = new KVMHABase.HAStoragePool(pool, host, path, pool.getLocalPath(), PoolType.PrimaryStorage, pool.getAuthUserName(), pool.getAuthSecret(), pool.getSourceHost());
-                _haMonitor.addRbdStoragePool(rbdPool);
-            } else if (type == StoragePoolType.CLVM && primaryStorage) {
-                KVMHABase.HAStoragePool clvmPool = new KVMHABase.HAStoragePool(pool, host, path, PoolType.PrimaryStorage);
-                _haMonitor.addClvmStoragePool(clvmPool);
-            }
-        }
-
+        syncStoragePoolHeartbeatMonitoring(pool, host, path, type, details, primaryStorage);
 
         StoragePoolInformation info = new StoragePoolInformation(name, host, port, path, userInfo, type, details, primaryStorage);
         addStoragePool(pool.getUuid(), info);
         return pool;
+    }
+
+    protected void syncStoragePoolHeartbeatMonitoring(KVMStoragePool pool, String host, String path, StoragePoolType type, Map<String, String> details, boolean primaryStorage) {
+        _haMonitor.removeStoragePoolFromMonitoring(pool.getUuid());
+
+        if (!primaryStorage || MapUtils.isEmpty(details) || !details.containsKey(KVM_HA_ON_STORAGE_HEARTBEAT)) {
+            return;
+        }
+
+        if (!"true".equals(details.get(KVM_HA_ON_STORAGE_HEARTBEAT))) {
+            logger.info("Disabled KVM HA storage heartbeat monitoring for storage pool [{}].", pool.getUuid());
+            return;
+        }
+
+        // LibvirtStorageAdaptor-specific statement
+        if (type == StoragePoolType.NetworkFilesystem) {
+            KVMHABase.HAStoragePool storagePool = new KVMHABase.HAStoragePool(pool, host, path, PoolType.PrimaryStorage);
+            _haMonitor.addStoragePool(storagePool);
+        } else if (type == StoragePoolType.SharedMountPoint) {
+            KVMHABase.HAStoragePool gfsPool = new KVMHABase.HAStoragePool(pool, host, path, PoolType.PrimaryStorage);
+            _haMonitor.addGfsStoragePool(gfsPool);
+        } else if (type == StoragePoolType.RBD) {
+            KVMHABase.HAStoragePool rbdPool = new KVMHABase.HAStoragePool(pool, host, path, pool.getLocalPath(), PoolType.PrimaryStorage, pool.getAuthUserName(), pool.getAuthSecret(), pool.getSourceHost());
+            _haMonitor.addRbdStoragePool(rbdPool);
+        } else if (type == StoragePoolType.CLVM) {
+            KVMHABase.HAStoragePool clvmPool = new KVMHABase.HAStoragePool(pool, host, path, PoolType.PrimaryStorage);
+            _haMonitor.addClvmStoragePool(clvmPool);
+        }
+        logger.info("Enabled KVM HA storage heartbeat monitoring for storage pool [{}] of type [{}].", pool.getUuid(), type);
     }
 
     public boolean disconnectPhysicalDisk(StoragePoolType type, String poolUuid, String volPath) {

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -138,6 +138,8 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.cloud.agent.AgentManager;
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.ModifyStoragePoolCommand;
 import com.cloud.alert.AlertManager;
 import com.cloud.api.ApiDBUtils;
 import com.cloud.api.query.dao.NetworkOfferingJoinDao;
@@ -196,6 +198,7 @@ import com.cloud.exception.PermissionDeniedException;
 import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.gpu.GPU;
+import com.cloud.ha.HighAvailabilityManager;
 import com.cloud.host.HostTagVO;
 import com.cloud.host.HostVO;
 import com.cloud.host.dao.HostDao;
@@ -263,6 +266,7 @@ import com.cloud.storage.Volume;
 import com.cloud.storage.VolumeApiServiceImpl;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.DiskOfferingDao;
+import com.cloud.storage.dao.StoragePoolHostDao;
 import com.cloud.storage.dao.StoragePoolTagsDao;
 import com.cloud.storage.dao.VMTemplateZoneDao;
 import com.cloud.storage.dao.VolumeDao;
@@ -461,6 +465,8 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     HostTagsDao hostTagDao;
     @Inject
     StoragePoolTagsDao storagePoolTagDao;
+    @Inject
+    StoragePoolHostDao storagePoolHostDao;
     @Inject
     private AnnotationDao annotationDao;
     @Inject
@@ -768,8 +774,10 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     List<StoragePoolVO> childDataStores = _storagePoolDao.listChildStoragePoolsInDatastoreCluster(resourceId);
                     for (StoragePoolVO childDataStore: childDataStores) {
                         _storagePoolDetailsDao.addDetail(childDataStore.getId(), name, value, true);
+                        syncKvmStoragePoolHeartbeatSettingWithHosts(childDataStore, name);
                     }
                 }
+                syncKvmStoragePoolHeartbeatSettingWithHosts(pool, name);
 
                 break;
 
@@ -917,6 +925,29 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         txn.commit();
         messageBus.publish(_name, EventTypes.EVENT_CONFIGURATION_VALUE_EDIT, PublishScope.GLOBAL, name);
         return _configDao.getValue(name);
+    }
+
+    protected void syncKvmStoragePoolHeartbeatSettingWithHosts(StoragePoolVO pool, String name) {
+        if (!HighAvailabilityManager.KvmHACheckOnStorage.key().equals(name)) {
+            return;
+        }
+
+        List<Long> poolIds = new ArrayList<>();
+        poolIds.add(pool.getId());
+        List<Long> hostIds = storagePoolHostDao.findHostsConnectedToPools(poolIds);
+        Map<String, String> details = _storagePoolDetailsDao.listDetailsKeyPairs(pool.getId());
+
+        for (Long hostId : hostIds) {
+            logger.info("Syncing KVM HA storage heartbeat setting [{}={}] for pool [{}] with host [{}].",
+                    name, details.get(name), pool, _hostDao.findById(hostId));
+            ModifyStoragePoolCommand command = new ModifyStoragePoolCommand(true, pool, details);
+            Answer answer = _agentManager.easySend(hostId, command);
+            if (answer == null) {
+                logger.warn("Unable to sync KVM HA storage heartbeat setting for pool [{}] on host [{}] because the agent returned no answer.", pool, _hostDao.findById(hostId));
+            } else if (!answer.getResult()) {
+                logger.warn("Unable to sync KVM HA storage heartbeat setting for pool [{}] on host [{}] due to [{}].", pool, _hostDao.findById(hostId), answer.getDetails());
+            }
+        }
     }
 
     private boolean shouldEncryptValue(String category) {

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -192,6 +192,7 @@ import com.cloud.exception.ResourceInUseException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.exception.StorageConflictException;
 import com.cloud.exception.StorageUnavailableException;
+import com.cloud.ha.HighAvailabilityManager;
 import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.host.Status;
@@ -1267,10 +1268,30 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
                 }
                 _storagePoolDao.update(id, storagePool);
                 _storagePoolDao.updateDetails(id, details);
+                syncKvmStoragePoolHeartbeatSettingWithHosts(storagePool, inputDetails, details);
             }
         }
 
         return (PrimaryDataStoreInfo)_dataStoreMgr.getDataStore(pool.getId(), DataStoreRole.Primary);
+    }
+
+    protected void syncKvmStoragePoolHeartbeatSettingWithHosts(StoragePoolVO storagePool, Map<String, String> inputDetails, Map<String, String> details) {
+        if (MapUtils.isEmpty(inputDetails) || !inputDetails.containsKey(HighAvailabilityManager.KvmHACheckOnStorage.key())) {
+            return;
+        }
+
+        List<Long> poolIds = new ArrayList<>();
+        poolIds.add(storagePool.getId());
+        List<Long> hostIds = _storagePoolHostDao.findHostsConnectedToPools(poolIds);
+        for (Long hostId : hostIds) {
+            ModifyStoragePoolCommand cmd = new ModifyStoragePoolCommand(true, storagePool, details);
+            Answer answer = _agentMgr.easySend(hostId, cmd);
+            if (answer == null) {
+                logger.warn("Unable to sync KVM HA storage heartbeat setting for pool {} on host {} because the agent returned no answer.", storagePool, _hostDao.findById(hostId));
+            } else if (!answer.getResult()) {
+                logger.warn("Unable to sync KVM HA storage heartbeat setting for pool {} on host {} due to {}.", storagePool, _hostDao.findById(hostId), answer.getDetails());
+            }
+        }
     }
 
     private void changeStoragePoolScopeToZone(StoragePoolVO primaryStorage) {


### PR DESCRIPTION

[Mold Diplo] 기본스토리지의 "kvm.ha.on.storage.heartbeat" 값 변경 시 호스트 agent 재시작 없이 HA heartbeat 대상 스토리지 monitor 목록 갱신
  - `kvm.ha.on.storage.heartbeat` 변경 시 연결된 KVM agent에 설정 재전송
  - agent 재시작 없이 HA heartbeat 대상 스토리지 monitor 목록 갱신
  - true/false 변경에 따라 HA monitor 등록/해제 처리

### PR 설명

이 PR은 ...
<!--- 변경 사항에 대해 자세하게 설명하십시오. 그리고 변경사항을 어떻게 실행하는지도 설명합니다. -->

<!-- 새로운 기능에 대한 PR인 경우, 타당성 조사(FS) 및 디자인 컨셉(DS) 등에 대한 위키 또는 문서 등을 링크합니다. -->
<!-- 버그 수정에 대한 PR인 경우, 재현을 위한 과정과 기대 실행 및 실제 실행 결과에 대한 내용을 설명합니다. -->

<!-- "Fixes #<id>"를 사용하면 해당 이슈 및 PR이 관련 이슈/PR로 등록되어 PR이 Merge 될 때 자동으로 종료됩니다. -->
<!-- 여려 개의 이슈 또는 PR을 지정하고자 하는 경우, 여러 개의 "Fixes #<id>"를 작성합니다. -->
<!-- Fixes # -->


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [ ] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [x] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [x] 주요 기능/개선
- [ ] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [ ] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [ ] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->


