### PR TITLE
ssl 인증서 비밀번호 있는 키를 PKCS#8 형태로 저장할 수 있도록 기능 개선

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/loadbalancer/UploadSslCertCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/loadbalancer/UploadSslCertCmd.java
@@ -37,7 +37,7 @@ import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
 import org.apache.cloudstack.network.tls.CertService;
 
-@APICommand(name = "uploadSslCert", description = "Upload a certificate to CloudStack", responseObject = SslCertResponse.class,
+@APICommand(name = "uploadSslCert", description = "Upload a certificate to ABLESTACK", responseObject = SslCertResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class UploadSslCertCmd extends BaseCmd {
 
@@ -54,7 +54,7 @@ public class UploadSslCertCmd extends BaseCmd {
 
     @Parameter(name = ApiConstants.PRIVATE_KEY, type = CommandType.STRING, required = true,
             description = "PEM formatted private key. Supported formats: unencrypted PKCS#8, encrypted PKCS#8, and OpenSSL legacy RSA/DSA/EC private keys. " +
-                    "Encrypted keys are decrypted using the password parameter and stored as unencrypted PKCS#8 PEM protected by CloudStack encryption.",
+                    "Encrypted keys are decrypted using the password parameter and stored as unencrypted PKCS#8 PEM protected by ABLESTACK encryption.",
             length = 16384)
     private String key;
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/loadbalancer/UploadSslCertCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/loadbalancer/UploadSslCertCmd.java
@@ -52,13 +52,17 @@ public class UploadSslCertCmd extends BaseCmd {
     @Parameter(name = ApiConstants.CERTIFICATE, type = CommandType.STRING, required = true, description = "SSL certificate", length = 16384)
     private String cert;
 
-    @Parameter(name = ApiConstants.PRIVATE_KEY, type = CommandType.STRING, required = true, description = "Private key", length = 16384)
+    @Parameter(name = ApiConstants.PRIVATE_KEY, type = CommandType.STRING, required = true,
+            description = "PEM formatted private key. Supported formats: unencrypted PKCS#8, encrypted PKCS#8, and OpenSSL legacy RSA/DSA/EC private keys. " +
+                    "Encrypted keys are decrypted using the password parameter and stored as unencrypted PKCS#8 PEM protected by CloudStack encryption.",
+            length = 16384)
     private String key;
 
     @Parameter(name = ApiConstants.CERTIFICATE_CHAIN, type = CommandType.STRING, description = "Certificate chain of trust", length = 2097152)
     private String chain;
 
-    @Parameter(name = ApiConstants.PASSWORD, type = CommandType.STRING, description = "Password for the private key")
+    @Parameter(name = ApiConstants.PASSWORD, type = CommandType.STRING,
+            description = "Password used to decrypt an encrypted private key during upload. The password is not stored after the key is normalized.")
     private String password;
 
     @Parameter(name = ApiConstants.ACCOUNT, type = CommandType.STRING, description = "account that will own the SSL certificate")

--- a/server/src/main/java/org/apache/cloudstack/network/ssl/CertServiceImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/network/ssl/CertServiceImpl.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.network.ssl;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringReader;
+import java.io.StringWriter;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
@@ -76,6 +77,7 @@ import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
 import org.bouncycastle.pkcs.PKCSException;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemReader;
+import org.bouncycastle.util.io.pem.PemWriter;
 
 import com.cloud.domain.DomainVO;
 import com.cloud.domain.dao.DomainDao;
@@ -134,7 +136,8 @@ public class CertServiceImpl implements CertService {
         final String chain = certCmd.getChain();
         final String name = certCmd.getName();
 
-        validate(cert, key, password, chain, certCmd.getEnabledRevocationCheck());
+        final PrivateKey privateKey = validateAndGetPrivateKey(cert, key, password, chain, certCmd.getEnabledRevocationCheck());
+        final String normalizedKey = normalizePrivateKey(privateKey);
         logger.debug("Certificate Validation succeeded");
 
         final String fingerPrint = CertificateHelper.generateFingerPrint(parseCertificate(cert));
@@ -152,7 +155,7 @@ public class CertServiceImpl implements CertService {
         final Long accountId = owner.getId();
         final Long domainId = owner.getDomainId();
 
-        final SslCertVO certVO = new SslCertVO(cert, key, password, chain, accountId, domainId, fingerPrint, name);
+        final SslCertVO certVO = new SslCertVO(cert, normalizedKey, null, chain, accountId, domainId, fingerPrint, name);
         _sslCertDao.persist(certVO);
 
         return createCertResponse(certVO, null);
@@ -288,6 +291,10 @@ public class CertServiceImpl implements CertService {
     }
 
     protected void validate(final String certInput, final String keyInput, final String password, final String chainInput, boolean revocationEnabled) {
+        validateAndGetPrivateKey(certInput, keyInput, password, chainInput, revocationEnabled);
+    }
+
+    protected PrivateKey validateAndGetPrivateKey(final String certInput, final String keyInput, final String password, final String chainInput, boolean revocationEnabled) {
         try {
             List<Certificate> chain = null;
             final Certificate cert = parseCertificate(certInput);
@@ -303,10 +310,35 @@ public class CertServiceImpl implements CertService {
             if (chainInput != null) {
                 validateChain(chain, cert, revocationEnabled);
             }
+
+            return key;
         } catch (final IOException | CertificateException | OperatorCreationException | PKCSException |
                        NoSuchAlgorithmException | InvalidKeySpecException e) {
             logger.warn("Failed to validate certificate", e);
             throw new IllegalStateException("Parsing certificate/key failed: " + e.getMessage(), e);
+        }
+    }
+
+    protected String convertPrivateKeyToPkcs8Pem(final PrivateKey privateKey) {
+        Preconditions.checkNotNull(privateKey);
+        final byte[] encodedKey = privateKey.getEncoded();
+        Preconditions.checkArgument(encodedKey != null && encodedKey.length > 0, "Private key cannot be encoded");
+
+        try (StringWriter stringWriter = new StringWriter(); PemWriter pemWriter = new PemWriter(stringWriter)) {
+            pemWriter.writeObject(new PemObject("PRIVATE KEY", encodedKey));
+            pemWriter.flush();
+            return stringWriter.toString();
+        } catch (IOException e) {
+            throw new CloudRuntimeException("Failed to encode private key to PKCS#8 PEM", e);
+        }
+    }
+
+    protected String normalizePrivateKey(final PrivateKey privateKey) {
+        try {
+            return convertPrivateKeyToPkcs8Pem(privateKey);
+        } catch (RuntimeException e) {
+            logger.warn("Failed to normalize private key to PKCS#8 PEM", e);
+            throw new IllegalStateException("Private key cannot be converted to unencrypted PKCS#8 PEM: " + e.getMessage(), e);
         }
     }
 

--- a/server/src/test/java/com/cloud/network/lb/LoadBalancingRulesManagerImplTest.java
+++ b/server/src/test/java/com/cloud/network/lb/LoadBalancingRulesManagerImplTest.java
@@ -41,6 +41,7 @@ import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.command.user.loadbalancer.UpdateLoadBalancerRuleCmd;
 import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.resourcedetail.FirewallRuleDetailVO;
 import org.apache.cloudstack.resourcedetail.dao.FirewallRuleDetailsDao;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.junit.Assert;
@@ -220,6 +221,12 @@ public class LoadBalancingRulesManagerImplTest{
         when(certMapRule.getId()).thenReturn(certMapRuleId);
     }
 
+    private void mockBackendSslDetail(boolean enabled) {
+        FirewallRuleDetailVO backendSslDetail = Mockito.mock(FirewallRuleDetailVO.class);
+        when(backendSslDetail.getValue()).thenReturn(Boolean.toString(enabled));
+        when(_firewallRuleDetailsDao.findDetail(lbRuleId, ApiConstants.BACKEND_SSL)).thenReturn(backendSslDetail);
+    }
+
     @Test
     public void testUpdateLoadBalancerRule1() throws Exception {
         setupUpdateLoadBalancerRule();
@@ -248,6 +255,23 @@ public class LoadBalancingRulesManagerImplTest{
 
         lbr.updateLoadBalancerRule(cmd);
 
+        Mockito.verify(_lbCertMapDao, times(1)).remove(anyLong());
+        Mockito.verify(lbr, times(1)).applyLoadBalancerConfig(lbRuleId);
+    }
+
+    @Test
+    public void testUpdateLoadBalancerRuleFromSslToTcpRemovesBackendSslDetail() throws Exception {
+        setupUpdateLoadBalancerRule();
+        mockBackendSslDetail(true);
+
+        UpdateLoadBalancerRuleCmd cmd = new UpdateLoadBalancerRuleCmd();
+        ReflectionTestUtils.setField(cmd, ApiConstants.ID, lbRuleId);
+        ReflectionTestUtils.setField(cmd, "lbProtocol", NetUtils.TCP_PROTO);
+        when(loadBalancerMock.getLbProtocol()).thenReturn(NetUtils.SSL_PROTO).thenReturn(NetUtils.TCP_PROTO);
+
+        lbr.updateLoadBalancerRule(cmd);
+
+        Mockito.verify(_firewallRuleDetailsDao, times(1)).removeDetail(lbRuleId, ApiConstants.BACKEND_SSL);
         Mockito.verify(_lbCertMapDao, times(1)).remove(anyLong());
         Mockito.verify(lbr, times(1)).applyLoadBalancerConfig(lbRuleId);
     }

--- a/server/src/test/java/org/apache/cloudstack/network/ssl/CertServiceTest.java
+++ b/server/src/test/java/org/apache/cloudstack/network/ssl/CertServiceTest.java
@@ -46,6 +46,7 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -58,6 +59,7 @@ import java.nio.charset.Charset;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -267,6 +269,14 @@ public class CertServiceTest {
         passField.set(uploadCmd, password);
 
         certService.uploadSslCert(uploadCmd);
+
+        ArgumentCaptor<SslCertVO> certCaptor = ArgumentCaptor.forClass(SslCertVO.class);
+        Mockito.verify(certService._sslCertDao).persist(certCaptor.capture());
+        SslCertVO persistedCert = certCaptor.getValue();
+        Assert.assertNull(persistedCert.getPassword());
+        Assert.assertTrue(persistedCert.getKey().contains("-----BEGIN PRIVATE KEY-----"));
+        Assert.assertFalse(persistedCert.getKey().contains("ENCRYPTED"));
+        certService.parsePrivateKey(persistedCert.getKey(), null);
     }
 
     @Test
@@ -316,6 +326,41 @@ public class CertServiceTest {
         certService.uploadSslCert(uploadCmd);
         Mockito.verify(uploadCmd, Mockito.atLeastOnce()).getAccountName();
         Mockito.verify(uploadCmd, Mockito.times(1)).getCert();
+    }
+
+    @Test
+    public void runUploadSslCertShouldNotPersistWhenPrivateKeyCannotBeNormalized() throws Exception {
+
+        final String certFile = URLDecoder.decode(getClass().getResource("/certs/rsa_self_signed.crt").getFile(),Charset.defaultCharset().name());
+        final String keyFile = URLDecoder.decode(getClass().getResource("/certs/rsa_self_signed.key").getFile(),Charset.defaultCharset().name());
+
+        final String cert = readFileToString(new File(certFile));
+        final String key = readFileToString(new File(keyFile));
+
+        final CertServiceImpl certService = Mockito.spy(new CertServiceImpl());
+        certService._sslCertDao = Mockito.mock(SslCertDao.class);
+        Mockito.doThrow(new IllegalStateException("Private key cannot be converted to unencrypted PKCS#8 PEM"))
+                .when(certService).normalizePrivateKey(ArgumentMatchers.any(PrivateKey.class));
+
+        final UploadSslCertCmd uploadCmd = new UploadSslCertCmdExtn();
+        final Class<?> klazz = uploadCmd.getClass().getSuperclass();
+
+        final Field certField = klazz.getDeclaredField("cert");
+        certField.setAccessible(true);
+        certField.set(uploadCmd, cert);
+
+        final Field keyField = klazz.getDeclaredField("key");
+        keyField.setAccessible(true);
+        keyField.set(uploadCmd, key);
+
+        try {
+            certService.uploadSslCert(uploadCmd);
+            Assert.fail("Given a private key that cannot be normalized to PKCS#8 PEM, upload should fail.");
+        } catch (final Exception e) {
+            Assert.assertTrue("Did not expect message: " + e.getMessage(),
+                    e.getMessage().contains("Private key cannot be converted to unencrypted PKCS#8 PEM"));
+        }
+        Mockito.verify(certService._sslCertDao, Mockito.never()).persist(ArgumentMatchers.any(SslCertVO.class));
     }
 
     @Test
@@ -860,7 +905,12 @@ public class CertServiceTest {
         String password = "strongpassword";
         String key = generateEncryptedPrivateKey(password);
         final CertServiceImpl certService = new CertServiceImpl();
-        certService.parsePrivateKey(key, password);
+        PrivateKey privateKey = certService.parsePrivateKey(key, password);
+        String normalizedKey = certService.convertPrivateKeyToPkcs8Pem(privateKey);
+
+        Assert.assertTrue(normalizedKey.contains("-----BEGIN PRIVATE KEY-----"));
+        Assert.assertFalse(normalizedKey.contains("ENCRYPTED"));
+        certService.parsePrivateKey(normalizedKey, null);
     }
 
     @Test

--- a/ui/public/locales/ko_KR.json
+++ b/ui/public/locales/ko_KR.json
@@ -1822,7 +1822,7 @@
 "label.private.registry": "\uc0ac\uc124 \ub808\uc9c0\uc2a4\ud2b8\ub9ac",
 "label.privateinterface": "\uc0ac\uc124 \uc778\ud130\ud398\uc774\uc2a4",
 "label.privateip": "\uc0ac\uc124 IP \uc8fc\uc18c",
-"label.privatekey": "PKC#8 \ube44\ubc00 \ud0a4",
+"label.privatekey": "\uac1c\uc778\ud0a4",
 "label.privatenetwork": "\uc0ac\uc124 \ub124\ud2b8\uc6cc\ud06c",
 "label.privateport": "\uc0ac\uc124 \ud3ec\ud2b8",
 "label.profilename": "\uc815\ubcf4",


### PR DESCRIPTION
### PR 설명

기존 부하분산 기능은 SSL 인증서가 비밀번호 없는 PKCS#8 만 허용 가능하도록 기능이 개발되어 있었음
그래서 RSA+비밀번호 키 조합, PKCS#8+비밀번호 키조합 인증서 사용시 가상라우터 haproxy.cfg가 적용 안되고
SSL이 동작 안하는 문제를 해결하기 위해

RSA+비밀번호 키 조합, PKCS#8+비밀번호 키조합 인증서 사용시 입력받은 개인키를 비밀번호 없는 PKCS#8로 변환하여
Mold 부하분산에 사용 가능한 pem 파일로 변환할 수 있도록 기능 개선

<!--- 변경 사항에 대해 자세하게 설명하십시오. 그리고 변경사항을 어떻게 실행하는지도 설명합니다. -->

<!-- 새로운 기능에 대한 PR인 경우, 타당성 조사(FS) 및 디자인 컨셉(DS) 등에 대한 위키 또는 문서 등을 링크합니다. -->
<!-- 버그 수정에 대한 PR인 경우, 재현을 위한 과정과 기대 실행 및 실제 실행 결과에 대한 내용을 설명합니다. -->

<!-- "Fixes #<id>"를 사용하면 해당 이슈 및 PR이 관련 이슈/PR로 등록되어 PR이 Merge 될 때 자동으로 종료됩니다. -->
<!-- 여려 개의 이슈 또는 PR을 지정하고자 하는 경우, 여러 개의 "Fixes #<id>"를 작성합니다. -->
<!-- Fixes # -->


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [ ] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [x] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [ ] 주요 기능/개선
- [x] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [ ] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [ ] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->


