### PR TITLE
[Mold Diplo] KVM HA activity check 대상 스토리지 필터링 개선

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckVMActivityOnStoragePoolCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCheckVMActivityOnStoragePoolCommandWrapper.java
@@ -47,28 +47,15 @@ public final class LibvirtCheckVMActivityOnStoragePoolCommandWrapper extends Com
         final StorageFilerTO pool = command.getPool();
         final KVMStoragePoolManager storagePoolMgr = libvirtComputingResource.getStoragePoolMgr();
 
+        HAStoragePool haStoragePool = getMonitoredStoragePool(monitor, pool);
+        if (haStoragePool == null) {
+            executors.shutdownNow();
+            return new Answer(command, false, "Unsupported Storage or HA pool not found");
+        }
+
         KVMStoragePool primaryPool = storagePoolMgr.getStoragePool(pool.getType(), pool.getUuid());
         if (primaryPool.isPoolSupportHA()){
-            HAStoragePool haStoragePool = null;
-            String vmActivityCheckPath = "";
-            if (Storage.StoragePoolType.NetworkFilesystem == pool.getType()) {
-                haStoragePool = monitor.getStoragePool(pool.getUuid());
-                vmActivityCheckPath = libvirtComputingResource.getVmActivityCheckPath();
-            } else if (Storage.StoragePoolType.SharedMountPoint == pool.getType()) {
-                haStoragePool = monitor.getGfsStoragePool(pool.getUuid());
-                vmActivityCheckPath = libvirtComputingResource.getVmActivityCheckPathGfs();
-            } else if (Storage.StoragePoolType.RBD == pool.getType()) {
-                haStoragePool = monitor.getRbdStoragePool(pool.getUuid());
-                vmActivityCheckPath = libvirtComputingResource.getVmActivityCheckPathRbd();
-            } else if (Storage.StoragePoolType.CLVM == pool.getType()) {
-                haStoragePool = monitor.getClvmStoragePool(pool.getUuid());
-                vmActivityCheckPath = libvirtComputingResource.getVmActivityCheckPathClvm();
-            }
-
-            if (haStoragePool == null) {
-                executors.shutdownNow();
-                return new Answer(command, false, "Unsupported Storage or HA pool not found");
-            }
+            String vmActivityCheckPath = getVmActivityCheckPath(libvirtComputingResource, pool);
 
             final KVMHAVMActivityChecker ha = new KVMHAVMActivityChecker(haStoragePool, command.getHost(), command.getVolumeList(), vmActivityCheckPath, command.getSuspectTimeInSeconds());
             final Future<Boolean> future = executors.submit(ha);
@@ -90,5 +77,31 @@ public final class LibvirtCheckVMActivityOnStoragePoolCommandWrapper extends Com
         }
         executors.shutdownNow();
         return new Answer(command, false, "Unsupported Storage");
+    }
+
+    protected HAStoragePool getMonitoredStoragePool(final KVMHAMonitor monitor, final StorageFilerTO pool) {
+        if (Storage.StoragePoolType.NetworkFilesystem == pool.getType()) {
+            return monitor.getStoragePool(pool.getUuid());
+        } else if (Storage.StoragePoolType.SharedMountPoint == pool.getType()) {
+            return monitor.getGfsStoragePool(pool.getUuid());
+        } else if (Storage.StoragePoolType.RBD == pool.getType()) {
+            return monitor.getRbdStoragePool(pool.getUuid());
+        } else if (Storage.StoragePoolType.CLVM == pool.getType()) {
+            return monitor.getClvmStoragePool(pool.getUuid());
+        }
+        return null;
+    }
+
+    protected String getVmActivityCheckPath(final LibvirtComputingResource libvirtComputingResource, final StorageFilerTO pool) {
+        if (Storage.StoragePoolType.NetworkFilesystem == pool.getType()) {
+            return libvirtComputingResource.getVmActivityCheckPath();
+        } else if (Storage.StoragePoolType.SharedMountPoint == pool.getType()) {
+            return libvirtComputingResource.getVmActivityCheckPathGfs();
+        } else if (Storage.StoragePoolType.RBD == pool.getType()) {
+            return libvirtComputingResource.getVmActivityCheckPathRbd();
+        } else if (Storage.StoragePoolType.CLVM == pool.getType()) {
+            return libvirtComputingResource.getVmActivityCheckPathClvm();
+        }
+        return "";
     }
 }

--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/kvm/ha/KVMHostActivityChecker.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/kvm/ha/KVMHostActivityChecker.java
@@ -189,6 +189,10 @@ public class KVMHostActivityChecker extends AdapterBase implements ActivityCheck
         boolean activityStatus = true;
         HashMap<StoragePool, List<Volume>> poolVolMap = getVolumeUuidOnHost(agent);
         for (StoragePool pool : poolVolMap.keySet()) {
+            if (!isStoragePoolHeartbeatEnabled(pool)) {
+                logger.debug("Skipping VM activity check for {} on storage pool [{}] because KVM HA storage heartbeat is not enabled for the pool.", agent, pool);
+                continue;
+            }
             activityStatus = verifyActivityOfStorageOnHost(poolVolMap, pool, agent, suspectTime, activityStatus);
             if (!activityStatus) {
                 logger.warn("It seems that the storage pool [{}] does not have activity on {}.", pool, agent);
@@ -197,6 +201,13 @@ public class KVMHostActivityChecker extends AdapterBase implements ActivityCheck
         }
 
         return activityStatus;
+    }
+
+    protected boolean isStoragePoolHeartbeatEnabled(StoragePool pool) {
+        if (pool == null) {
+            return false;
+        }
+        return Boolean.TRUE.equals(HighAvailabilityManager.KvmHACheckOnStorage.valueIn(pool.getId()));
     }
 
     protected boolean verifyActivityOfStorageOnHost(HashMap<StoragePool, List<Volume>> poolVolMap, StoragePool pool, Host agent, DateTime suspectTime, boolean activityStatus) throws HACheckerException, IllegalStateException {


### PR DESCRIPTION
### PR 설명


[Mold Diplo] KVM HA activity check 대상 스토리지 필터링 개선
- KVM HA activity check 시 storage heartbeat가 활성화된 primary storage만 검사하도록 수정
- Agent에서도 HA monitor에 등록되지 않은 pool은 libvirt 조회 전에 skip하여 불필요한 지연과 timeout 가능성 낮춤


<!--- 변경 사항에 대해 자세하게 설명하십시오. 그리고 변경사항을 어떻게 실행하는지도 설명합니다. -->

<!-- 새로운 기능에 대한 PR인 경우, 타당성 조사(FS) 및 디자인 컨셉(DS) 등에 대한 위키 또는 문서 등을 링크합니다. -->
<!-- 버그 수정에 대한 PR인 경우, 재현을 위한 과정과 기대 실행 및 실제 실행 결과에 대한 내용을 설명합니다. -->

<!-- "Fixes #<id>"를 사용하면 해당 이슈 및 PR이 관련 이슈/PR로 등록되어 PR이 Merge 될 때 자동으로 종료됩니다. -->
<!-- 여려 개의 이슈 또는 PR을 지정하고자 하는 경우, 여러 개의 "Fixes #<id>"를 작성합니다. -->
<!-- Fixes # -->


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [ ] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [x] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [x] 주요 기능/개선
- [ ] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [ ] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [ ] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->


