### PR TITLE
[Mold Diplo] KVM 호스트의 stale 2차스토리지 NFS ISO 마운트 정리 보완

### DIFF
--- a/packaging/systemd/cloudstack-agent.service
+++ b/packaging/systemd/cloudstack-agent.service
@@ -22,7 +22,7 @@
 [Unit]
 Description=Mold Agent
 Documentation=http://www.cloudstack.org/
-Requires=libvirtd.service
+Wants=libvirtd.service
 After=libvirtd.service
 
 [Service]

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KVMHAMonitor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/KVMHAMonitor.java
@@ -34,19 +34,29 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class KVMHAMonitor extends KVMHABase implements Runnable {
 
+    private static final long SECONDARY_NFS_ISO_MOUNT_CLEANUP_COOLDOWN_MS = 60 * 1000L;
+
     private final Map<String, HAStoragePool> storagePool = new ConcurrentHashMap<>();
     private final Map<String, HAStoragePool> storageGfsPool = new ConcurrentHashMap<>();
     private final Map<String, HAStoragePool> storageRbdPool = new ConcurrentHashMap<>();
     private final Map<String, HAStoragePool> storageClvmPool = new ConcurrentHashMap<>();
     private final boolean rebootHostAndAlertManagementOnHeartbeatTimeout;
+    private final Runnable secondaryNfsIsoMountCleanup;
+    private long lastSecondaryNfsIsoMountCleanupTime;
 
     private final String hostPrivateIp;
 
     public KVMHAMonitor(HAStoragePool pool, String host, String scriptPath, String scriptPathGfs, String scriptPathRbd, String scriptPathClvm) {
+        this(pool, host, scriptPath, scriptPathGfs, scriptPathRbd, scriptPathClvm, null);
+    }
+
+    public KVMHAMonitor(HAStoragePool pool, String host, String scriptPath, String scriptPathGfs, String scriptPathRbd, String scriptPathClvm,
+            Runnable secondaryNfsIsoMountCleanup) {
         if (pool != null) {
             storagePool.put(pool.getPoolUUID(), pool);
         }
         hostPrivateIp = host;
+        this.secondaryNfsIsoMountCleanup = secondaryNfsIsoMountCleanup;
         configureHeartBeatPath(scriptPath, scriptPathGfs, scriptPathRbd, scriptPathClvm);
         rebootHostAndAlertManagementOnHeartbeatTimeout = AgentPropertiesFileHandler.getPropertyValue(AgentProperties.REBOOT_HOST_AND_ALERT_MANAGEMENT_ON_HEARTBEAT_TIMEOUT);
     }
@@ -249,8 +259,26 @@ public class KVMHAMonitor extends KVMHABase implements Runnable {
             if (e.toString().contains("pool not found")) {
                 logger.debug(String.format("Removing pool [%s] from HA monitor since it was deleted.", uuid));
                 removedPools.add(uuid);
+            } else {
+                cleanupSecondaryNfsIsoMountsOnLibvirtFailure(uuid);
             }
         }
+    }
+
+    private void cleanupSecondaryNfsIsoMountsOnLibvirtFailure(String poolUuid) {
+        if (secondaryNfsIsoMountCleanup == null) {
+            return;
+        }
+
+        long currentTime = System.currentTimeMillis();
+        if (currentTime - lastSecondaryNfsIsoMountCleanupTime < SECONDARY_NFS_ISO_MOUNT_CLEANUP_COOLDOWN_MS) {
+            logger.debug(String.format("Skipping secondary NFS ISO mount cleanup after libvirt lookup failure for pool [%s] because cooldown is active.", poolUuid));
+            return;
+        }
+
+        lastSecondaryNfsIsoMountCleanupTime = currentTime;
+        logger.warn(String.format("Checking secondary NFS ISO mounts after libvirt lookup failure for pool [%s].", poolUuid));
+        secondaryNfsIsoMountCleanup.run();
     }
 
     @Override

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -25,7 +25,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
+import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -267,6 +269,14 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     protected static Logger LOGGER = LogManager.getLogger(LibvirtComputingResource.class);
     private static final String CONFIG_VALUES_SEPARATOR = ",";
+    private static final String PROC_MOUNTS_PATH = "/proc/mounts";
+    private static final String SECONDARY_STORAGE_NFS_PATH = "/nfs/secondary";
+    private static final String LIBVIRT_NFS_MOUNT_ROOT = "/mnt/";
+    private static final int NFS_SERVICE_PORT = 2049;
+    private static final int NFS_CONNECT_TIMEOUT_MS = 3000;
+    private static final int NFS_CONNECT_RETRY_COUNT = 5;
+    private static final long NFS_CONNECT_RETRY_INTERVAL_MS = 1000L;
+    private static final Pattern LIBVIRT_NFS_MOUNT_POINT_PATTERN = Pattern.compile("^" + Pattern.quote(LIBVIRT_NFS_MOUNT_ROOT) + "[0-9a-fA-F-]{36}$");
 
     private static final String LEGACY = "legacy";
     private static final String SECURE = "secure";
@@ -691,6 +701,141 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     public KVMStoragePoolManager getStoragePoolMgr() {
         return storagePoolManager;
+    }
+
+    @Override
+    public void disconnected() {
+        cleanupUnavailableSecondaryNfsIsoMountsSafely("management server disconnect");
+    }
+
+    protected void cleanupUnavailableSecondaryNfsIsoMountsSafely(String reason) {
+        try {
+            cleanupUnavailableSecondaryNfsIsoMounts(reason);
+        } catch (RuntimeException e) {
+            LOGGER.warn("Failed to cleanup unavailable secondary NFS ISO mounts during [{}].", reason, e);
+        }
+    }
+
+    protected void cleanupUnavailableSecondaryNfsIsoMounts(String reason) {
+        List<SecondaryNfsIsoMount> mounts = getMountedSecondaryNfsIsoMounts();
+        if (mounts.isEmpty()) {
+            LOGGER.debug("No secondary NFS ISO mounts found to check during [{}].", reason);
+            return;
+        }
+
+        LOGGER.warn("Checking [{}] secondary NFS ISO mount(s) during [{}].", mounts.size(), reason);
+        Map<String, Boolean> nfsServerAvailability = new HashMap<>();
+        for (SecondaryNfsIsoMount mount : mounts) {
+            try {
+                boolean nfsReachable = nfsServerAvailability.computeIfAbsent(mount.host, this::isNfsServiceReachable);
+                if (nfsReachable) {
+                    LOGGER.debug("Keeping secondary NFS ISO mount [{}] because NFS server [{}] is still reachable.", mount.mountPoint, mount.host);
+                    continue;
+                }
+
+                LOGGER.warn("Secondary NFS ISO mount [{}] from source [{}] is stale. Starting forced lazy unmount.", mount.mountPoint, mount.source);
+                lazyUnmountSecondaryNfsIsoMount(mount, reason);
+            } catch (RuntimeException e) {
+                LOGGER.warn("Failed to process secondary NFS ISO mount [{}] from source [{}].", mount.mountPoint, mount.source, e);
+            }
+        }
+    }
+
+    protected List<SecondaryNfsIsoMount> getMountedSecondaryNfsIsoMounts() {
+        List<String> mountLines;
+        try {
+            mountLines = Files.readAllLines(Paths.get(PROC_MOUNTS_PATH));
+        } catch (IOException e) {
+            LOGGER.warn("Failed to read [{}] while checking secondary NFS ISO mounts.", PROC_MOUNTS_PATH, e);
+            return Collections.emptyList();
+        }
+
+        List<SecondaryNfsIsoMount> mounts = new ArrayList<>();
+        for (String line : mountLines) {
+            SecondaryNfsIsoMount mount = parseSecondaryNfsIsoMount(line);
+            if (mount != null) {
+                mounts.add(mount);
+            }
+        }
+        return mounts;
+    }
+
+    protected SecondaryNfsIsoMount parseSecondaryNfsIsoMount(String mountLine) {
+        if (StringUtils.isBlank(mountLine)) {
+            return null;
+        }
+
+        String[] tokens = mountLine.split("\\s+");
+        if (tokens.length < 3) {
+            return null;
+        }
+
+        String source = tokens[0];
+        String mountPoint = tokens[1];
+        String filesystemType = tokens[2];
+        if (!isNfsFilesystem(filesystemType) || !LIBVIRT_NFS_MOUNT_POINT_PATTERN.matcher(mountPoint).matches()) {
+            return null;
+        }
+
+        String host = StringUtils.substringBefore(source, ":");
+        String path = StringUtils.substringAfter(source, ":");
+        if (StringUtils.isAnyBlank(host, path) || !path.startsWith(SECONDARY_STORAGE_NFS_PATH)) {
+            return null;
+        }
+
+        return new SecondaryNfsIsoMount(source, host, mountPoint);
+    }
+
+    protected boolean isNfsFilesystem(String filesystemType) {
+        return "nfs".equalsIgnoreCase(filesystemType) || "nfs4".equalsIgnoreCase(filesystemType);
+    }
+
+    protected boolean isNfsServiceReachable(String host) {
+        for (int attempt = 1; attempt <= NFS_CONNECT_RETRY_COUNT; attempt++) {
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress(host, NFS_SERVICE_PORT), NFS_CONNECT_TIMEOUT_MS);
+                return true;
+            } catch (IOException | RuntimeException e) {
+                LOGGER.warn("NFS server [{}] is not reachable on port [{}] on attempt [{}/{}].",
+                        host, NFS_SERVICE_PORT, attempt, NFS_CONNECT_RETRY_COUNT);
+                if (attempt < NFS_CONNECT_RETRY_COUNT) {
+                    sleepBeforeNextNfsConnectRetry();
+                }
+            }
+        }
+        LOGGER.warn("NFS server [{}] is not reachable on port [{}] after [{}] attempts. Treating related secondary ISO mounts as stale.",
+                host, NFS_SERVICE_PORT, NFS_CONNECT_RETRY_COUNT);
+        return false;
+    }
+
+    protected void sleepBeforeNextNfsConnectRetry() {
+        try {
+            Thread.sleep(NFS_CONNECT_RETRY_INTERVAL_MS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    protected void lazyUnmountSecondaryNfsIsoMount(SecondaryNfsIsoMount mount, String reason) {
+        LOGGER.warn("Lazy unmounting stale secondary NFS ISO mount [{}] from source [{}] during [{}].", mount.mountPoint, mount.source, reason);
+        int exitValue = Script.runSimpleBashScriptForExitValue(String.format("umount -lf %s", mount.mountPoint));
+        if (exitValue == 0) {
+            LOGGER.info("Successfully lazy unmounted stale secondary NFS ISO mount [{}].", mount.mountPoint);
+        } else {
+            LOGGER.warn("Failed to lazy unmount stale secondary NFS ISO mount [{}]. Exit value: [{}].", mount.mountPoint, exitValue);
+        }
+    }
+
+    protected static class SecondaryNfsIsoMount {
+        protected final String source;
+        protected final String host;
+        protected final String mountPoint;
+
+        protected SecondaryNfsIsoMount(String source, String host, String mountPoint) {
+            this.source = source;
+            this.host = host;
+            this.mountPoint = mountPoint;
+        }
     }
 
     public String getPrivateIp() {
@@ -1353,7 +1498,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
         final String[] info = NetUtils.getNetworkParams(privateNic);
 
-        kvmhaMonitor = new KVMHAMonitor(null, info[0], heartBeatPath, heartBeatPathGfs, heartBeatPathRbd, heartBeatPathClvm);
+        kvmhaMonitor = new KVMHAMonitor(null, info[0], heartBeatPath, heartBeatPathGfs, heartBeatPathRbd, heartBeatPathClvm,
+                () -> cleanupUnavailableSecondaryNfsIsoMountsSafely("libvirt storage pool lookup failure"));
 
         final Thread ha = new Thread(kvmhaMonitor);
         ha.start();


### PR DESCRIPTION
### PR 설명

### 1. Mold Agent와 libvirtd 의존성 완화
- `cloudstack-agent.service`의 `Requires=libvirtd.service`를 `Wants=libvirtd.service`로 변경했습니다.
- libvirtd 장애/재시작 상황에서 agent가 함께 강제 종료되지 않도록 완화했습니다.
- 기동 순서는 기존처럼 `After=libvirtd.service`를 유지합니다.

### 2. 2차스토리지 NFS ISO 마운트 정리 로직 추가
- KVM 호스트에 남아있는 2차스토리지 ISO NFS 마운트를 `/proc/mounts` 기준으로 확인합니다.
- `/mnt/<uuid>` 형태의 libvirt ISO 마운트 중 source path가 `/nfs/secondary`인 NFS/NFS4 마운트만 대상으로 처리합니다.
- NFS 서버의 2049 포트 연결 가능 여부를 확인합니다.
- 5회 재시도, 각 연결 시도 3초 타임아웃 기준으로 NFS 서버가 응답하지 않으면 stale mount로 판단합니다.
- stale mount는 `umount -lf` 방식으로 lazy unmount 처리합니다.

### 3. 체크 시점 보완
- Mold 관리서버 연결이 끊긴 경우 agent의 `disconnected()`에서 1차 확인합니다.
- libvirt storage pool 조회 실패 시 `KVMHAMonitor`에서도 동일한 정리 로직을 호출하도록 보완했습니다.
- HA 모니터 쪽 호출은 반복 실행을 줄이기 위해 60초 cooldown을 적용했습니다.

## 처리 흐름

1. Mold 관리서버 연결 끊김 또는 HA 모니터의 libvirt pool 조회 실패가 발생합니다.
2. KVM 호스트의 `/proc/mounts`에서 2차스토리지 ISO NFS 마운트 후보를 조회합니다.
3. `/mnt/<uuid>` 경로이고, NFS source가 `/nfs/secondary` 하위인 항목만 필터링합니다.
4. 해당 NFS 서버의 2049 포트 접속 가능 여부를 확인합니다.
5. 5회 시도 후에도 접속 실패 시 stale mount로 판단합니다.
6. stale mount에 대해 `umount -lf`를 수행합니다.
7. 성공/실패 결과를 agent 로그에 기록합니다.

## 영향 범위

- KVM hypervisor host
- Mold Agent systemd unit
- 시스템 VM/가상머신에 ISO가 attach되면서 생성된 2차스토리지 NFS 마운트
- HA 모니터의 libvirt storage pool 조회 실패 처리 흐름

## 제외 사항

- Primary Storage 마운트는 대상이 아닙니다.
- `/nfs/secondary` 경로가 아닌 NFS 마운트는 해제하지 않습니다.
- NFS 서버 2049 포트가 정상 응답하는 경우 마운트를 유지합니다.
- 실제 2차스토리지 장애를 복구하는 기능은 아니며, 호스트에 남은 stale ISO mount를 정리하는 목적입니다.


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [ ] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [x] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [x] 주요 기능/개선
- [ ] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [ ] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [ ] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->


