### PR TITLE
Diplo UI 테마 및 전역 레이아웃 후속 개선

### DIFF
--- a/docs/design/diplo-theme-consistency-followup.md
+++ b/docs/design/diplo-theme-consistency-followup.md
@@ -1,0 +1,51 @@
+# Diplo 테마 일관성 후속 반영 설계
+
+## 1. 목적
+
+`ablestack-europa`에 먼저 반영된 전역 UI 개선 중 `ablestack-diplo`에 누락된 항목을
+Diplo의 API 호출 규칙과 화면 구성은 유지하면서 반영한다. 대상은 최근 이벤트/경고
+표시 레이어, UI 표시 설정 진입점, 전역 레이아웃, 컨텍스트 메뉴와 콘솔 동작이다.
+
+## 2. AS-IS / TO-BE
+
+| 구분 | AS-IS | TO-BE |
+|---|---|---|
+| 최근 활동 | 우측 오버레이 또는 화면별 진입점에 의존 | 화면 하단의 크기 조절 가능한 이벤트/경고 패널로 통합 |
+| 표시 설정 | 헤더의 독립 버튼으로 노출 | 사용자 메뉴의 표시 설정 항목으로 이동 |
+| 전역 레이아웃 | 하단 활동 패널을 위한 높이/overflow 계약 없음 | 본문과 활동 패널을 flex column으로 구성하고 본문만 독립 스크롤 |
+| 컨텍스트 메뉴 | 일부 액션 아이콘/상태/간격이 화면별로 다름 | 공통 리소스 액션 메뉴 토큰과 아이콘 정렬 규칙 사용 |
+| 콘솔 URL | Cloud API로 생성한 endpoint만 처리 | 리소스에 외부 콘솔 URL이 있으면 이를 우선 사용하고 API 호출 생략 |
+| 라우트 판별 | `$route.meta.name`에만 의존 | meta 값이 없으면 `$route.name`으로 안전하게 대체 |
+| API 호출 | Europa의 `getAPI`/`postAPI`와 Diplo의 `api`가 혼재할 위험 | Diplo 기존 `api()` 호출 규칙으로 통일 |
+
+## 3. 코드 반영 대상
+
+| 영역 | 파일 | 변경 내용 |
+|---|---|---|
+| 전역 레이아웃 | `ui/src/components/page/GlobalLayout.vue` | 활동 패널을 본문 아래에 배치하고 높이/스크롤 상태를 관리 |
+| 헤더 | `ui/src/components/page/GlobalHeader.vue`, `ui/src/components/header/HeaderNotice.vue` | 경고 표시와 헤더 액션 위치 정리 |
+| 사용자 메뉴 | `ui/src/components/header/UserMenu.vue` | 표시 설정과 활동 패널 진입점을 사용자 메뉴에 배치 |
+| 활동 패널 | `ui/src/components/view/EventSidebar.vue` | 이벤트/경고 탭, 주기 갱신, 접기, 높이 조절, 데이터 테이블 구현 |
+| 액션 | `ui/src/components/view/ActionButton.vue`, `ui/src/components/view/ResourceActionMenu.vue` | 라우트 fallback, 외부 콘솔 URL, 공통 액션 표시 정합성 보완 |
+| 드로어/로그인 | `ui/src/components/widgets/Drawer.vue`, `ui/src/layouts/UserLayout.vue` | 전역 레이아웃과 겹치지 않는 높이/표면 처리 |
+| 스타일 | `ui/src/style/index.less`, `ui/src/style/components/view/resource-context-menu.less` | 좁은 스크롤바, 패널/컨텍스트 메뉴 토큰과 dark/light 일관성 적용 |
+| 메뉴 구성 | `ui/src/config/section/compute.js`, `ui/src/config/section/network.js` | 기존 동작 위치와 중복되는 표시 항목 정리 |
+
+## 4. 병합 원칙
+
+1. Diplo의 `api()` 호출과 기존 메뉴 구조를 기준으로 유지한다.
+2. Europa 변경에서 화면 동작과 스타일만 가져오며 `getAPI`/`postAPI`로 회귀하지 않는다.
+3. 전역 스타일은 `--ui-*` 토큰을 사용하고 dark/light 테마별 하드코딩을 추가하지 않는다.
+4. 사용자 작업 파일과 빌드 산출물은 커밋하지 않는다.
+
+## 5. 검증 및 배포 게이트
+
+1. 활동 패널, 헤더 진입점, 액션 버튼 단위 테스트를 실행한다.
+2. UI production build를 완료하고 생성된 `index.html`의 JS/CSS asset이 실제 파일과 일치하는지 확인한다.
+3. origin 전체 릴리즈 빌드는 `noredist` 기본값과 KVM SystemVM artifact 생성을 유지한다.
+4. 테스트 서버에는 변경된 UI 패키지만 안전하게 배포한다. DB, 관리 서버 backend,
+   agent, SystemVM 변경이 없으므로 해당 구성요소는 교체하지 않는다.
+5. 배포 후 `/client/`와 index가 참조하는 모든 asset의 HTTP 200을 확인하고,
+   배포 파일 해시가 빌드 artifact와 동일한지 검증한다.
+6. 브라우저에서 로그인 화면, dark/light 전환, 이벤트/경고 패널, 사용자 메뉴의 표시
+   설정, 리소스 컨텍스트 액션을 확인한다.

--- a/docs/design/resource-context-menu-design.md
+++ b/docs/design/resource-context-menu-design.md
@@ -1,3 +1,22 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
 # 리소스 컨텍스트 메뉴 통합 설계
 
 ## 목적

--- a/ui/src/components/header/HeaderNotice.vue
+++ b/ui/src/components/header/HeaderNotice.vue
@@ -57,6 +57,12 @@
               </template>
             </a-list-item-meta>
           </a-list-item>
+          <a-list-item v-if="canOpenActivityPanel" class="header-notice-activity-link">
+            <a-button type="link" block @click="openActivityPanel">
+              <template #icon><calendar-outlined /></template>
+              {{ $t('label.recent.events') }} / {{ $t('label.alerts') }}
+            </a-button>
+          </a-list-item>
         </a-list>
       </a-spin>
     </template>
@@ -86,6 +92,11 @@ export default {
       }
     }
   },
+  computed: {
+    canOpenActivityPanel () {
+      return 'listEvents' in this.$store.getters.apis || 'listAlerts' in this.$store.getters.apis
+    }
+  },
   methods: {
     showNotifications () {
       this.visible = !this.visible
@@ -93,6 +104,10 @@ export default {
     clearJobs () {
       this.notices = this.notices.filter(x => x.status === 'progress')
       this.$store.commit('SET_HEADER_NOTICES', this.notices)
+    },
+    openActivityPanel () {
+      this.visible = false
+      this.$emit('open-activity-panel')
     },
     getResourceName (description, data) {
       if (description) {
@@ -139,6 +154,19 @@ export default {
     &-icon {
       font-size: 18px;
       padding: 4px;
+    }
+  }
+
+  .header-notice-activity-link {
+    padding: 4px 8px 0;
+
+    .ant-btn {
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+      gap: 8px;
+      padding: 0 8px;
+      text-align: left;
     }
   }
 </style>

--- a/ui/src/components/header/UserMenu.vue
+++ b/ui/src/components/header/UserMenu.vue
@@ -22,7 +22,9 @@
     </span>
     <external-link class="action"/>
     <translation-menu class="action"/>
-    <header-notice class="action"/>
+    <header-notice
+      class="action"
+      @open-activity-panel="$emit('open-activity-panel')" />
     <label class="user-menu-server-info action" v-if="$config.multipleServer">
       <database-outlined />
       {{ server.name || server.apiBase || 'Local-Server' }}
@@ -54,6 +56,13 @@
             <ClockCircleOutlined class="user-menu-item-icon" />
             <span class="user-menu-item-name" style="margin-right: 5px">{{ $t('label.use.local.timezone') }}</span>
             <a-switch :checked="$store.getters.usebrowsertimezone" />
+          </a-menu-item>
+          <a-menu-item
+            v-if="canOpenDisplaySettings"
+            class="user-menu-item"
+            key="display-settings">
+            <SettingOutlined class="user-menu-item-icon" />
+            <span class="user-menu-item-name">{{ $t('label.theme.page.style.setting') }}</span>
           </a-menu-item>
           <a-menu-item class="user-menu-item" key="document">
             <QuestionCircleOutlined class="user-menu-item-icon" />
@@ -88,6 +97,7 @@ import { mapActions, mapGetters } from 'vuex'
 import ResourceIcon from '@/components/view/ResourceIcon'
 import eventBus from '@/config/eventBus'
 import { SERVER_MANAGER } from '@/store/mutation-types'
+import { isAdmin } from '@/role'
 
 export default {
   name: 'UserMenu',
@@ -141,6 +151,9 @@ export default {
     }
   },
   computed: {
+    canOpenDisplaySettings () {
+      return isAdmin() && (process.env.NODE_ENV === 'development' || this.$config.allowSettingTheme)
+    },
     server () {
       return this.$localStorage.get(SERVER_MANAGER) || this.$config.servers[0]
     }
@@ -180,6 +193,9 @@ export default {
           break
         case 'timezone':
           this.toggleUseBrowserTimezone()
+          break
+        case 'display-settings':
+          this.$emit('open-display-settings')
           break
         case 'document':
           window.open(this.$config.docBase, '_blank')

--- a/ui/src/components/page/GlobalHeader.vue
+++ b/ui/src/components/page/GlobalHeader.vue
@@ -28,7 +28,10 @@
       </template>
       <project-menu />
       <saml-domain-switcher style="margin-left: 20px" />
-      <user-menu :device="device"></user-menu>
+      <user-menu
+        :device="device"
+        @open-activity-panel="$emit('open-activity-panel')"
+        @open-display-settings="$emit('open-display-settings')" />
     </div>
     <div v-else :class="['top-nav-header-index', theme]">
       <div class="header-index-wide">
@@ -47,7 +50,9 @@
         </div>
         <project-menu />
         <saml-domain-switcher style="margin-left: 20px" />
-        <user-menu></user-menu>
+        <user-menu
+          @open-activity-panel="$emit('open-activity-panel')"
+          @open-display-settings="$emit('open-display-settings')" />
       </div>
     </div>
 

--- a/ui/src/components/page/GlobalLayout.vue
+++ b/ui/src/components/page/GlobalLayout.vue
@@ -16,8 +16,12 @@
 
     <div class="banner-spacer" :style="{ height: combinedBannerHeight + 'px' }" aria-hidden="true"></div>
 
-    <a-layout class="layout" :class="[device]">
-      <div class="sticky-sidebar">
+    <a-layout
+      class="layout global-workbench"
+      :class="[device]"
+      :style="{ height: 'calc(100dvh - ' + combinedBannerHeight + 'px)' }">
+      <div class="global-workbench__main">
+        <div class="sticky-sidebar">
         <template v-if="isSideMenu()">
           <a-drawer
             v-if="isMobile()"
@@ -33,7 +37,6 @@
               :collapsed="false"
               :collapsible="true"
               mode="inline"
-              :style="{ paddingBottom: isSidebarVisible ? '300px' : '0' }"
               @menuSelect="menuSelect"
             />
           </a-drawer>
@@ -45,7 +48,6 @@
             :theme="navTheme"
             :collapsed="collapsed"
             :collapsible="true"
-            :style="{ paddingBottom: isSidebarVisible ? '300px' : '0' }"
           />
         </template>
 
@@ -64,7 +66,6 @@
               :collapsed="false"
               :collapsible="true"
               mode="inline"
-              :style="{ paddingBottom: isSidebarVisible ? '300px' : '0' }"
               @menuSelect="menuSelect"
             />
           </a-drawer>
@@ -73,83 +74,62 @@
         <drawer
           :visible="showSetting"
           placement="right"
+          :showHandler="false"
+          :title="$t('label.theme.page.style.setting')"
           v-if="isAdmin && (isDevelopmentMode || allowSettingTheme)"
         >
-          <template #handler>
-            <div
-              style="position: absolute; bottom: 55px; display: flex; flex-direction: column; gap: 0; align-items: flex-end; z-index: 1001; pointer-events: auto;"
-            >
-              <a-button
-                v-show="!showSetting"
-                type="primary"
-                @click.stop="toggleSidebar"
-                style="width: 40px; height: 40px; padding: 0; background: #aaa; border: none; color: #fff; border-radius: 4px 4px 0 0; display: flex; align-items: center; justify-content: center; cursor: pointer;"
-              >
-                <ScheduleOutlined />
-              </a-button>
-              <a-button
-                type="primary"
-                size="large"
-                @click.stop="toggleSetting(!showSetting)"
-                style="width: 40px; height: 40px; border-radius: 0 0 4px 4px; display: flex; align-items: center; justify-content: center; cursor: pointer;"
-              >
-                <close-outlined v-if="showSetting" />
-                <setting-outlined v-else />
-              </a-button>
-            </div>
-          </template>
           <template #drawer>
             <setting :visible="showSetting" />
           </template>
         </drawer>
-      </div>
-
-      <event-sidebar
-        :isVisible="isSidebarVisible"
-        ref="eventSidebar"
-        @update:isVisible="isSidebarVisible = $event"
-      />
-
-      <a-layout
-        :class="[layoutMode, `content-width-${contentWidth}`]"
-        :style="{ paddingLeft: contentPaddingLeft, minHeight: '100vh', paddingBottom: isSidebarVisible ? '300px' : '0' }"
-      >
-        <div class="sticky-header">
-          <global-header
-            :mode="layoutMode"
-            :menus="menus"
-            :theme="navTheme"
-            :collapsed="collapsed"
-            :device="device"
-            @toggle="toggle"
-          />
         </div>
 
-        <a-button
-          v-if="showClear"
-          type="default"
-          size="small"
-          class="button-clear-notification"
-          @click="onClearNotification"
-        >
-          {{ $t('label.clear.notification') }}
-        </a-button>
+        <div
+          class="global-workbench__workspace"
+          :style="{ paddingLeft: contentPaddingLeft }">
+          <a-layout
+            class="global-workbench__content"
+            :class="[layoutMode, `content-width-${contentWidth}`]">
+            <div class="sticky-header">
+              <global-header
+                :mode="layoutMode"
+                :menus="menus"
+                :theme="navTheme"
+                :collapsed="collapsed"
+                :device="device"
+                @toggle="toggle"
+                @open-activity-panel="toggleSidebar"
+                @open-display-settings="toggleSetting(true)"
+              />
+            </div>
 
-        <a-layout-content
-          class="layout-content"
-          :class="{ 'is-header-fixed': fixedHeader }"
-          :style="{ paddingBottom: isSidebarVisible ? '300px' : '0' }"
-        >
-          <slot />
-        </a-layout-content>
+            <a-button
+              v-if="showClear"
+              type="default"
+              size="small"
+              class="button-clear-notification"
+              @click="onClearNotification"
+            >
+              {{ $t('label.clear.notification') }}
+            </a-button>
 
-        <a-layout-footer
-          style="padding: 0; transition: padding-bottom 0.3s;"
-          :style="{ paddingBottom: isSidebarVisible ? '300px' : '0' }"
-        >
-          <global-footer />
-        </a-layout-footer>
-      </a-layout>
+            <a-layout-content
+              class="layout-content"
+              :class="{ 'is-header-fixed': fixedHeader }">
+              <slot />
+            </a-layout-content>
+
+            <a-layout-footer style="padding: 0">
+              <global-footer />
+            </a-layout-footer>
+          </a-layout>
+
+          <event-sidebar
+            :isVisible="isSidebarVisible"
+            ref="eventSidebar"
+            @update:isVisible="isSidebarVisible = $event" />
+        </div>
+      </div>
     </a-layout>
   </div>
 </template>
@@ -355,7 +335,6 @@ export default {
 
     toggleSidebar () {
       this.isSidebarVisible = true
-      this.$refs.eventSidebar.openSiderBar()
     },
     ...mapActions(['setSidebar']),
     toggle () {
@@ -393,6 +372,56 @@ export default {
 </script>
 
 <style lang="less">
+/* Main application and bottom activity panel share the viewport without overlap. */
+.global-workbench {
+  min-height: 0 !important;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column !important;
+
+  &__main {
+    flex: 1 1 auto;
+    min-height: 0;
+    min-width: 0;
+    display: flex;
+    overflow: hidden;
+  }
+
+  &__workspace {
+    flex: 1 1 auto;
+    min-height: 0;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    box-sizing: border-box;
+  }
+
+  &__content {
+    flex: 1 1 auto;
+    min-height: 0 !important;
+    min-width: 0;
+    overflow: hidden;
+
+    > .layout-content {
+      min-height: 0;
+      overflow-y: auto;
+      box-sizing: border-box;
+      padding-block-end: 16px;
+      scroll-padding-block-end: 16px;
+      overscroll-behavior: contain;
+    }
+  }
+
+  .sticky-sidebar {
+    position: relative;
+    top: auto;
+    height: 100%;
+    max-height: 100%;
+    flex: 0 0 auto;
+  }
+}
+
 /* 배너 영역만큼 컨텐츠를 밀어내는 스페이서 */
 .banner-spacer {
   width: 100%;
@@ -422,7 +451,10 @@ body.dark-mode .banner-spacer::before {
 /* 고정 헤더 사용 시 컨텐츠 상단 여백 */
 .layout-content {
   &.is-header-fixed {
-    margin: 78px 12px 0;
+    margin: 78px 0 0;
+    padding-right: 12px;
+    padding-left: 12px;
+    box-sizing: border-box;
     transition: padding-bottom 0.3s ease;
   }
 }

--- a/ui/src/components/view/ActionButton.vue
+++ b/ui/src/components/view/ActionButton.vue
@@ -166,11 +166,14 @@ export default {
         this.onResourceChange(newItem)
       }
     },
-    '$route.meta.name' () {
+    routeName () {
       this.updateWallLinkUrl()
     }
   },
   computed: {
+    routeName () {
+      return this.$route?.meta?.name || this.$route?.name || ''
+    },
     dataViewMenuEntries () {
       const entries = []
       if (this.showConsoleButtons) {
@@ -187,7 +190,7 @@ export default {
         entries.push(this.createExternalLinkEntry('works', 'label.works.portal.url', 'LaptopOutlined', this.worksUrl))
       }
       if (this.wallLinkReady) {
-        entries.push(this.createExternalLinkEntry('wall', `label.wall.portal.${this.$route.meta.name}.url`, 'AreaChartOutlined', this.wallLinkUrl))
+        entries.push(this.createExternalLinkEntry('wall', `label.wall.portal.${this.routeName}.url`, 'AreaChartOutlined', this.wallLinkUrl))
       }
       if (this.showGenieButton) {
         entries.push(this.createExternalLinkEntry('genie', 'label.genie.portal.url', 'LaptopOutlined', this.genieUrl))
@@ -241,7 +244,7 @@ export default {
       }
       const requiredApis = ['listVirtualMachines', 'createConsoleEndpoint']
       const hasApis = requiredApis.every(apiName => apiName in this.$store.getters.apis)
-      return hasApis && ['vm', 'systemvm', 'router', 'ilbvm', 'vnfapp'].includes(this.$route.meta.name)
+      return hasApis && ['vm', 'systemvm', 'router', 'ilbvm', 'vnfapp'].includes(this.routeName)
     },
     consoleButtonDisabled () {
       if (!this.resource) {
@@ -251,7 +254,7 @@ export default {
     },
     showWorksButton () {
       return this.resource && this.resource.id && this.resource.worksvmip &&
-        this.$route.meta.name === 'desktopcluster' &&
+        this.routeName === 'desktopcluster' &&
         ('listDesktopClusters' in this.$store.getters.apis)
     },
     worksUrl () {
@@ -264,11 +267,11 @@ export default {
       if (this.selectedRowKeys && this.selectedRowKeys.length > 1) {
         return false
       }
-      return this.resource && this.resource.id && ['vm', 'host', 'cluster'].includes(this.$route.meta.name)
+      return this.resource && this.resource.id && ['vm', 'host', 'cluster'].includes(this.routeName)
     },
     showGenieButton () {
       return this.resource && this.resource.id &&
-        this.$route.meta.name === 'automationcontroller' &&
+        this.routeName === 'automationcontroller' &&
         ('listAutomationController' in this.$store.getters.apis)
     },
     genieUrl () {
@@ -278,7 +281,7 @@ export default {
       return `http://${this.resource.automationcontrollerpublicip}:80`
     },
     showOobmButton () {
-      return this.resource && this.resource.id && this.$route.meta.name === 'host'
+      return this.resource && this.resource.id && this.routeName === 'host'
     },
     oobmButtonDisabled () {
       if (!this.showOobmButton) {
@@ -296,7 +299,7 @@ export default {
       return `${protocol}://${address}:${port}`
     },
     showCubeButton () {
-      return this.resource && this.resource.id && this.$route.meta.name === 'host'
+      return this.resource && this.resource.id && this.routeName === 'host'
     },
     cubeUrl () {
       if (!this.showCubeButton) {
@@ -379,6 +382,18 @@ export default {
       if (!this.resource || !this.resource.id) {
         return
       }
+
+      const externalUrl = this.resource?.details?.['External:console_url']
+      if (externalUrl) {
+        if (copyUrlToClipboard) {
+          this.$copyText(externalUrl)
+          this.$message.success({ content: this.$t('label.copied.clipboard') })
+        } else {
+          window.open(externalUrl, '_blank')
+        }
+        return
+      }
+
       const params = { virtualmachineid: this.resource.id }
       api('createConsoleEndpoint', params).then(json => {
         const response = json?.createconsoleendpointresponse?.consoleendpoint
@@ -426,13 +441,13 @@ export default {
         }
 
         let finalUrl = ''
-        if (this.$route.meta.name === 'vm') {
+        if (this.routeName === 'vm') {
           const path = getValue('monitoring.wall.portal.vm.uri') || ''
           finalUrl = `${baseUrl}${path}&var-vm_uuid=${this.resource.id}`
-        } else if (this.$route.meta.name === 'host') {
+        } else if (this.routeName === 'host') {
           const path = getValue('monitoring.wall.portal.host.uri') || ''
           finalUrl = `${baseUrl}${path}&var-host=${this.resource.ipaddress}`
-        } else if (this.$route.meta.name === 'cluster') {
+        } else if (this.routeName === 'cluster') {
           const path = getValue('monitoring.wall.portal.cluster.uri') || ''
           finalUrl = `${baseUrl}${path}`
         }

--- a/ui/src/components/view/EventSidebar.vue
+++ b/ui/src/components/view/EventSidebar.vue
@@ -16,51 +16,111 @@
 // under the License.
 
 <template>
-  <a-drawer
-    :visible="isVisible"
-    :mask="false"
-    :maskClosable="false"
-    placement="bottom"
-    :height="300"
-    @close="closeSidebar"
-    :closable="false"
-  >
-    <div class="sidebar-header">
-      <span class="sidebar-title">{{ $t('label.recent.events') }}</span>
-      <a-button
-        v-if="isVisible"
-        type="primary"
-        class="close-btn"
-        @click="closeSidebar"
-        style="width: 40px; height: 40px; padding: 0;"
-      >
-        <close-outlined />
-      </a-button>
+  <section
+    v-show="isVisible"
+    class="bottom-activity-panel"
+    :class="{ 'is-collapsed': collapsed, 'is-resizing': resizing }"
+    :style="{ height: currentHeight + 'px' }"
+    aria-label="Activity panel">
+    <div
+      class="bottom-activity-panel__resize-handle"
+      role="separator"
+      aria-orientation="horizontal"
+      :aria-valuemin="minHeight"
+      :aria-valuemax="maxHeight"
+      :aria-valuenow="currentHeight"
+      tabindex="0"
+      @dblclick="resetHeight"
+      @keydown="onResizeKeydown"
+      @pointerdown="startResize">
+      <span aria-hidden="true"></span>
     </div>
 
-    <a-col :xs="{ span: 24 }" :lg="{ span: 24 }">
-      <!-- <chart-card :loading="loading" class="dashboard-card dashboard-event"> -->
-        <a-divider style="margin: 0px 0px; border-width: 0px" />
-        <a-table
-          :columns="columns"
-          :dataSource="events"
-          rowKey="id"
-          :bordered="false"
-          :pagination="false"
+    <header class="bottom-activity-panel__header">
+      <button
+        v-if="canListEvents"
+        type="button"
+        class="bottom-activity-panel__tab"
+        :class="{ 'is-active': activeTab === 'events' }"
+        :aria-selected="activeTab === 'events'"
+        @click="selectTab('events')">
+        {{ $t('label.recent.events') }}
+      </button>
+      <button
+        v-if="canListAlerts"
+        type="button"
+        class="bottom-activity-panel__tab"
+        :class="{ 'is-active': activeTab === 'alerts' }"
+        :aria-selected="activeTab === 'alerts'"
+        @click="selectTab('alerts')">
+        {{ $t('label.alerts') }}
+      </button>
+
+      <div class="bottom-activity-panel__header-actions">
+        <a-button
+          type="text"
           size="small"
-          class="event-table no-border-table"
-        >
-        </a-table>
-      <!-- </chart-card> -->
-    </a-col>
-  </a-drawer>
+          :aria-label="$t('label.close')"
+          @click="toggleCollapsed">
+          <up-outlined v-if="collapsed" />
+          <down-outlined v-else />
+        </a-button>
+        <a-button
+          type="text"
+          size="small"
+          :aria-label="$t('label.close')"
+          @click="closeSidebar">
+          <close-outlined />
+        </a-button>
+      </div>
+    </header>
+
+    <div v-show="!collapsed" class="bottom-activity-panel__body">
+      <a-table
+        v-if="activeTab === 'events'"
+        :columns="eventColumns"
+        :dataSource="events"
+        rowKey="id"
+        :bordered="false"
+        :pagination="false"
+        :scroll="{ x: 1160, y: tableBodyHeight }"
+        size="small"
+        class="bottom-activity-panel__table" />
+
+      <a-table
+        v-else
+        :columns="alertColumns"
+        :dataSource="alerts"
+        rowKey="id"
+        :bordered="false"
+        :pagination="false"
+        :scroll="{ x: 760, y: tableBodyHeight }"
+        size="small"
+        class="bottom-activity-panel__table" />
+    </div>
+
+    <footer v-show="!collapsed" class="bottom-activity-panel__footer">
+      <span>{{ activeRows.length }}</span>
+    </footer>
+  </section>
 </template>
 
 <script>
+import { DownOutlined, UpOutlined } from '@ant-design/icons-vue'
 import { api } from '@/api'
+
+const DEFAULT_HEIGHT = 220
+const MIN_HEIGHT = 140
+const COLLAPSED_HEIGHT = 36
+const MAX_HEIGHT = 520
+const HEIGHT_STORAGE_KEY = 'ablestack.bottomActivityPanel.height.v1'
 
 export default {
   name: 'EventSidebar',
+  components: {
+    DownOutlined,
+    UpOutlined
+  },
   props: {
     isVisible: {
       type: Boolean,
@@ -69,126 +129,181 @@ export default {
   },
   data () {
     return {
+      activeTab: 'events',
+      alerts: [],
+      collapsed: false,
       events: [],
-      loading: false,
+      eventListBarMinutes: 5 * 60 * 1000,
+      expandedHeight: DEFAULT_HEIGHT,
       refreshInterval: null,
-      columns: [
-        {
-          title: this.$t('label.level'),
-          dataIndex: 'level',
-          key: 'level',
-          width: 40,
-          ellipsis: true
-        },
-        {
-          title: this.$t('label.type'),
-          dataIndex: 'type',
-          key: 'type',
-          width: 120
-        },
-        {
-          title: this.$t('label.state'),
-          dataIndex: 'state',
-          key: 'state',
-          width: 50,
-          ellipsis: true
-        },
-        {
-          title: this.$t('label.description'),
-          dataIndex: 'description',
-          key: 'description',
-          width: 300
-        },
-        {
-          title: this.$t('label.resource'),
-          dataIndex: 'resourcename',
-          key: 'resourcename',
-          width: 80
-        },
-        {
-          title: this.$t('label.username'),
-          dataIndex: 'username',
-          key: 'username',
-          width: 40
-        },
-        {
-          title: this.$t('label.account'),
-          dataIndex: 'account',
-          key: 'account',
-          width: 40
-        },
-        {
-          title: this.$t('label.domain'),
-          dataIndex: 'domain',
-          key: 'domain',
-          width: 40,
-          ellipsis: true
-        },
+      resizing: false,
+      resizeStartHeight: DEFAULT_HEIGHT,
+      resizeStartY: 0,
+      eventColumns: [
+        { title: this.$t('label.level'), dataIndex: 'level', key: 'level', width: 80, ellipsis: true },
+        { title: this.$t('label.type'), dataIndex: 'type', key: 'type', width: 150, ellipsis: true },
+        { title: this.$t('label.state'), dataIndex: 'state', key: 'state', width: 100, ellipsis: true },
+        { title: this.$t('label.description'), dataIndex: 'description', key: 'description', width: 360, ellipsis: true },
+        { title: this.$t('label.resource'), dataIndex: 'resourcename', key: 'resourcename', width: 160, ellipsis: true },
+        { title: this.$t('label.username'), dataIndex: 'username', key: 'username', width: 120, ellipsis: true },
+        { title: this.$t('label.account'), dataIndex: 'account', key: 'account', width: 120, ellipsis: true },
+        { title: this.$t('label.domain'), dataIndex: 'domain', key: 'domain', width: 120, ellipsis: true },
         {
           title: this.$t('label.created'),
           dataIndex: 'created',
           key: 'created',
-          width: 100,
+          width: 170,
           ellipsis: true,
-          customRender: ({ text }) => {
-            return this.formatDate(text)
-          }
+          customRender: ({ text }) => this.formatDate(text)
         }
       ],
-      columnKeys: ['level', 'type', 'state', 'description', 'resourcename', 'username', 'account', 'domain', 'created']
+      alertColumns: [
+        { title: this.$t('label.name'), dataIndex: 'name', key: 'name', width: 180, ellipsis: true },
+        { title: this.$t('label.description'), dataIndex: 'description', key: 'description', width: 420, ellipsis: true },
+        { title: this.$t('label.type'), dataIndex: 'type', key: 'type', width: 120, ellipsis: true },
+        {
+          title: this.$t('label.sent'),
+          dataIndex: 'sent',
+          key: 'sent',
+          width: 170,
+          ellipsis: true,
+          customRender: ({ text }) => this.formatDate(text)
+        }
+      ]
     }
   },
-  created () {
+  computed: {
+    canListEvents () {
+      return 'listEvents' in this.$store.getters.apis
+    },
+    canListAlerts () {
+      return 'listAlerts' in this.$store.getters.apis
+    },
+    currentHeight () {
+      return this.collapsed ? COLLAPSED_HEIGHT : this.expandedHeight
+    },
+    minHeight () {
+      return this.collapsed ? COLLAPSED_HEIGHT : MIN_HEIGHT
+    },
+    maxHeight () {
+      return Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, Math.floor(window.innerHeight * 0.5)))
+    },
+    tableBodyHeight () {
+      return Math.max(54, this.expandedHeight - 94)
+    },
+    activeRows () {
+      return this.activeTab === 'events' ? this.events : this.alerts
+    }
+  },
+  watch: {
+    isVisible (visible) {
+      if (visible) {
+        this.openSidebar()
+      } else {
+        this.stopRefresh()
+      }
+    }
+  },
+  mounted () {
+    const storedHeight = Number(window.localStorage.getItem(HEIGHT_STORAGE_KEY))
+    if (Number.isFinite(storedHeight) && storedHeight > 0) {
+      this.expandedHeight = this.clampHeight(storedHeight)
+    }
+    if (!this.canListEvents && this.canListAlerts) {
+      this.activeTab = 'alerts'
+    }
+    if (this.isVisible) {
+      this.openSidebar()
+    }
+  },
+  beforeUnmount () {
+    this.stopRefresh()
+    this.stopResize()
   },
   methods: {
+    async openSidebar () {
+      this.collapsed = false
+      await this.loadRecentMinutes()
+      await this.fetchActiveTab()
+      this.startRefresh()
+    },
     openSiderBar () {
-      this.fetchEvents()
-      this.refreshInterval = setInterval(this.fetchEvents, 5000)
+      return this.openSidebar()
     },
     closeSidebar () {
-      clearInterval(this.refreshInterval)
+      this.stopRefresh()
       this.$emit('update:isVisible', false)
     },
-    async fetchEvents () {
-      if (!('listEvents' in this.$store.getters.apis)) {
-        return
+    toggleCollapsed () {
+      this.collapsed = !this.collapsed
+      if (this.collapsed) {
+        this.stopRefresh()
+      } else {
+        this.fetchActiveTab()
+        this.startRefresh()
       }
-      const params = {
-        page: 1,
-        pagesize: 20,
-        listall: true
+    },
+    selectTab (tab) {
+      this.activeTab = tab
+      if (this.collapsed) {
+        this.collapsed = false
       }
+      this.fetchActiveTab()
+      this.startRefresh()
+    },
+    startRefresh () {
+      this.stopRefresh()
+      if (!this.isVisible || this.collapsed) return
+      this.refreshInterval = window.setInterval(this.fetchActiveTab, 5000)
+    },
+    stopRefresh () {
+      if (this.refreshInterval) {
+        window.clearInterval(this.refreshInterval)
+        this.refreshInterval = null
+      }
+    },
+    async loadRecentMinutes () {
+      if (this.$store.getters.userInfo.roletype !== 'Admin') return
       try {
-        if (this.$store.getters.userInfo.roletype === 'Admin') {
-          const settingsResponse = await api('listConfigurations', { name: 'event.recent.minutes' })
-          const eventListBarSetting = settingsResponse?.listconfigurationsresponse?.configuration[0]?.value || 5
-          this.eventListBarMinutes = parseInt(eventListBarSetting, 10) * 60 * 1000
-        } else {
-          this.eventListBarMinutes = parseInt(5, 10) * 60 * 1000
-        }
-        const response = await api('listEvents', params)
-        if (response && response.listeventsresponse) {
-          const events = response.listeventsresponse.event || []
-          const recentEvents = this.filterRecentEvents(events, this.eventListBarMinutes)
-          this.events = recentEvents
-        } else {
-          console.error('No events found in the response')
-        }
+        const response = await api('listConfigurations', { name: 'event.recent.minutes' })
+        const minutes = Number(response?.listconfigurationsresponse?.configuration?.[0]?.value || 5)
+        this.eventListBarMinutes = minutes * 60 * 1000
+      } catch (error) {
+        console.error('Error getting recent event configuration:', error)
+      }
+    },
+    fetchActiveTab () {
+      return this.activeTab === 'alerts' ? this.fetchAlerts() : this.fetchEvents()
+    },
+    async fetchEvents () {
+      if (!this.canListEvents) return
+      try {
+        const response = await api('listEvents', { page: 1, pagesize: 20, listall: true })
+        const events = response?.listeventsresponse?.event || []
+        this.events = this.filterRecentEvents(events, this.eventListBarMinutes)
       } catch (error) {
         console.error('Error getting event list:', error)
-      } finally {
+      }
+    },
+    async fetchAlerts () {
+      if (!this.canListAlerts) return
+      try {
+        const response = await api('listAlerts', { page: 1, pagesize: 20, listall: true })
+        this.alerts = response?.listalertsresponse?.alert || []
+      } catch (error) {
+        console.error('Error getting alert list:', error)
       }
     },
     filterRecentEvents (events, timeRange = 5 * 60 * 1000) {
       const timeThreshold = Date.now() - timeRange
-      return events.filter(event => {
-        const eventTime = new Date(event.created).getTime()
-        return eventTime >= timeThreshold
-      }).slice(0, 20)
+      return events.filter(event => new Date(event.created).getTime() >= timeThreshold).slice(0, 20)
     },
     formatDate (dateString) {
+      if (!dateString) return '-'
       const date = new Date(dateString)
-      return new Intl.DateTimeFormat('en-GB', {
+      if (Number.isNaN(date.getTime())) return dateString
+      const locale = String(this.$i18n.locale || 'en-GB').replace('_', '-')
+      return new Intl.DateTimeFormat(locale, {
         day: '2-digit',
         month: 'short',
         year: 'numeric',
@@ -198,52 +313,216 @@ export default {
         hour12: false
       }).format(date)
     },
-    getEventColour (event) {
-      return 'blue'
+    startResize (event) {
+      if (this.collapsed || event.button !== 0) return
+      this.resizing = true
+      this.resizeStartY = event.clientY
+      this.resizeStartHeight = this.expandedHeight
+      if (event.currentTarget.setPointerCapture) {
+        event.currentTarget.setPointerCapture(event.pointerId)
+      }
+      window.addEventListener('pointermove', this.resizePanel)
+      window.addEventListener('pointerup', this.stopResize, { once: true })
+      document.body.classList.add('activity-panel-resizing')
+    },
+    resizePanel (event) {
+      if (!this.resizing) return
+      this.expandedHeight = this.clampHeight(this.resizeStartHeight + this.resizeStartY - event.clientY)
+    },
+    stopResize () {
+      if (!this.resizing) return
+      this.resizing = false
+      window.removeEventListener('pointermove', this.resizePanel)
+      document.body.classList.remove('activity-panel-resizing')
+      window.localStorage.setItem(HEIGHT_STORAGE_KEY, String(this.expandedHeight))
+    },
+    onResizeKeydown (event) {
+      if (!['ArrowUp', 'ArrowDown'].includes(event.key)) return
+      event.preventDefault()
+      if (this.collapsed) this.collapsed = false
+      const step = event.shiftKey ? 48 : 16
+      const direction = event.key === 'ArrowUp' ? 1 : -1
+      this.expandedHeight = this.clampHeight(this.expandedHeight + step * direction)
+      window.localStorage.setItem(HEIGHT_STORAGE_KEY, String(this.expandedHeight))
+    },
+    resetHeight () {
+      this.collapsed = false
+      this.expandedHeight = this.clampHeight(DEFAULT_HEIGHT)
+      window.localStorage.setItem(HEIGHT_STORAGE_KEY, String(this.expandedHeight))
+    },
+    clampHeight (height) {
+      return Math.min(this.maxHeight, Math.max(MIN_HEIGHT, Math.round(height)))
     }
   }
 }
 </script>
 
-<style scoped>
-.sidebar-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 14px;
-}
-.sidebar-title {
-  font-size: 16px;
-  font-weight: bold;
-  margin-right: auto;
+<style lang="less">
+.bottom-activity-panel {
+  position: relative;
+  flex: 0 0 auto;
+  min-width: 0;
+  color: var(--ui-text-secondary);
+  background: var(--ui-bg-surface);
+  border-top: 1px solid var(--ui-border);
+  overflow: hidden;
+
+  &.is-resizing { user-select: none; }
+
+  &__resize-handle {
+    position: absolute;
+    z-index: 2;
+    top: 0;
+    right: 0;
+    left: 0;
+    height: 6px;
+    cursor: ns-resize;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    span {
+      width: 42px;
+      height: 2px;
+      border-radius: 1px;
+      background: var(--ui-border);
+      opacity: 0;
+      transition: opacity 0.15s ease;
+    }
+
+    &:hover span,
+    &:focus span {
+      opacity: 1;
+      background: var(--ui-focus);
+    }
+  }
+
+  &__header {
+    height: 36px;
+    padding: 4px 8px 0;
+    display: flex;
+    align-items: flex-end;
+    gap: 4px;
+    background: var(--ui-bg-elevated);
+    border-bottom: 1px solid var(--ui-border);
+  }
+
+  &__tab {
+    height: 32px;
+    padding: 0 12px;
+    color: var(--ui-text-secondary);
+    background: transparent;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible { color: var(--ui-text-primary); }
+
+    &.is-active {
+      color: var(--ui-focus);
+      border-bottom-color: var(--ui-focus);
+    }
+  }
+
+  &__header-actions {
+    margin-left: auto;
+    height: 32px;
+    display: flex;
+    align-items: center;
+
+    .ant-btn {
+      width: 30px;
+      height: 30px;
+      padding: 0;
+      color: var(--ui-text-muted);
+
+      &:hover,
+      &:focus-visible {
+        color: var(--ui-text-primary);
+      }
+
+      .anticon {
+        display: inline-flex;
+        font-size: 14px;
+      }
+    }
+  }
+
+  &__body {
+    height: calc(100% - 58px);
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  &__table {
+    height: 100%;
+
+    .ant-table { font-size: 12px; }
+
+    .ant-table-thead > tr > th,
+    .ant-table-tbody > tr > td {
+      height: 30px;
+      padding: 4px 10px;
+      white-space: nowrap;
+    }
+
+    .ant-table-thead > tr > th {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      font-size: 12px;
+      font-weight: 600;
+    }
+
+    .ant-table-body,
+    .ant-table-content {
+      scrollbar-width: thin;
+      scrollbar-color: var(--ui-scroll-thumb) transparent;
+    }
+
+    .ant-table-body::-webkit-scrollbar,
+    .ant-table-content::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    .ant-table-body::-webkit-scrollbar-thumb,
+    .ant-table-content::-webkit-scrollbar-thumb {
+      background: var(--ui-scroll-thumb);
+      border-radius: 3px;
+    }
+  }
+
+  &__footer {
+    height: 22px;
+    padding: 0 10px;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    color: var(--ui-text-muted);
+    background: var(--ui-bg-elevated);
+    border-top: 1px solid var(--ui-border);
+    font-size: 11px;
+  }
+
+  &.is-collapsed {
+    .bottom-activity-panel__resize-handle { cursor: default; }
+    .bottom-activity-panel__header { border-bottom: 0; }
+  }
 }
 
-.close-btn {
-  position: fixed;
-  top: -40px;
-  right: 0px;
-  z-index: 1000;
-  background: #aaa;
-  border: none;
-  color: #666;
+body.activity-panel-resizing {
+  cursor: ns-resize !important;
+  user-select: none !important;
 }
 
-.no-border-table .ant-table-cell,
-.no-border-table .ant-table-thead > tr > th {
-  border: none;
-}
-
-a-table .ant-table-content {
-  overflow: auto;
-}
-
-a-table .ant-table-cell {
-  font-size: 10px;
-  line-height: 1.2;
-}
-
-a-table .ant-table-content .ant-table-row {
-  max-height: 200px;
-  overflow: auto;
+@media (max-width: 767px) {
+  .bottom-activity-panel__tab {
+    padding: 0 8px;
+    font-size: 12px;
+  }
 }
 </style>

--- a/ui/src/components/view/ResourceActionMenu.vue
+++ b/ui/src/components/view/ResourceActionMenu.vue
@@ -32,8 +32,10 @@
           @click="execute(entry)">
           <a-tooltip placement="right" :title="entry.disabled ? entry.tooltip : ''">
             <span class="resource-action-menu__item-content">
-              <render-icon v-if="typeof entry.icon === 'string'" :icon="entry.icon" />
-              <font-awesome-icon v-else-if="entry.icon" :icon="entry.icon" />
+              <span class="resource-action-menu__item-icon" aria-hidden="true">
+                <render-icon v-if="typeof entry.icon === 'string'" :icon="entry.icon" />
+                <font-awesome-icon v-else-if="entry.icon" :icon="entry.icon" />
+              </span>
               <span class="resource-action-menu__item-label">{{ $t(entry.label) }}</span>
               <a-badge
                 v-if="entry.badge"

--- a/ui/src/components/widgets/Drawer.vue
+++ b/ui/src/components/widgets/Drawer.vue
@@ -20,10 +20,23 @@
     <div :class="['mask', visible ? 'open' : 'close']" @click="close"></div>
     <div :class="['drawer', placement, visible ? 'open' : 'close']">
       <div ref="drawer" class="content">
-        <slot name="drawer"></slot>
+        <header v-if="title || closable" class="drawer-header">
+          <span class="drawer-title">{{ title }}</span>
+          <a-button
+            v-if="closable"
+            type="text"
+            :aria-label="$t('label.close')"
+            @click.stop="close">
+            <close-outlined />
+          </a-button>
+        </header>
+        <div class="drawer-body">
+          <slot name="drawer"></slot>
+        </div>
       </div>
 
       <div
+        v-if="showHandler && $slots.handler"
         :class="['handler-container', placement, visible ? 'open' : 'close']"
         ref="handler"
         @click="toggle">
@@ -59,6 +72,16 @@ export default {
       type: Boolean,
       required: false,
       default: true
+    },
+    closable: {
+      type: Boolean,
+      required: false,
+      default: true
+    },
+    title: {
+      type: String,
+      required: false,
+      default: ''
     }
   },
   inject: ['parentToggleSetting'],
@@ -123,9 +146,39 @@ export default {
 .content {
   display: inline-block;
   height: 100vh;
-  overflow-y: auto;
+  overflow: hidden;
   width: 300px;
-  background-color: #FFFFFF;
+  color: var(--ui-text-primary, rgba(0, 0, 0, 0.85));
+  background-color: var(--ui-bg-surface, #fff);
+}
+
+.drawer-header {
+  height: 52px;
+  padding: 0 12px 0 20px;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--ui-border, #f0f0f0);
+}
+
+.drawer-title {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  color: var(--ui-text-primary, rgba(0, 0, 0, 0.85));
+  font-size: 15px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.drawer-header .ant-btn {
+  flex: 0 0 auto;
+  color: var(--ui-text-muted, rgba(0, 0, 0, 0.45));
+}
+
+.drawer-body {
+  height: calc(100vh - 52px);
+  overflow-y: auto;
 }
 
 .handler-container {

--- a/ui/src/config/section/compute.js
+++ b/ui/src/config/section/compute.js
@@ -270,7 +270,7 @@ export default {
         },
         {
           api: 'createSnapshot',
-          icon: ['fas', 'camera-retro'],
+          icon: 'camera-outlined',
           label: 'label.action.vmstoragesnapshot.create',
           docHelp: 'adminguide/virtual_machines.html#virtual-machine-snapshots',
           dataView: true,

--- a/ui/src/config/section/network.js
+++ b/ui/src/config/section/network.js
@@ -507,7 +507,7 @@ export default {
         },
         {
           api: 'createSnapshot',
-          icon: ['fas', 'camera-retro'],
+          icon: 'camera-outlined',
           label: 'label.action.vmstoragesnapshot.create',
           docHelp: 'adminguide/virtual_machines.html#virtual-machine-snapshots',
           dataView: true,

--- a/ui/src/layouts/UserLayout.vue
+++ b/ui/src/layouts/UserLayout.vue
@@ -119,17 +119,19 @@ export default {
 <style lang="less" scoped>
 .user-layout {
   height: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
+  position: relative;
 
   &-container {
     padding: 3rem 0;
     width: 100%;
 
-    @media (min-height:600px) {
+    @media (min-height: 600px) {
       padding: 0;
       position: relative;
       top: 50%;
       transform: translateY(-50%);
-      margin-top: -50px;
     }
   }
 

--- a/ui/src/style/components/view/resource-context-menu.less
+++ b/ui/src/style/components/view/resource-context-menu.less
@@ -86,12 +86,26 @@
   gap: 10px;
 }
 
-.resource-action-menu__item-content .anticon,
-.resource-action-menu__item-content svg {
+.resource-action-menu__item-icon {
+  display: inline-flex;
   flex: 0 0 16px;
   width: 16px;
   height: 16px;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
   color: var(--ui-text-secondary);
+  line-height: 1;
+}
+
+.resource-action-menu__item-icon .anticon,
+.resource-action-menu__item-icon svg {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  line-height: 1;
+  vertical-align: middle;
 }
 
 .resource-action-menu__item-label {

--- a/ui/src/style/components/view/resource-context-menu.less
+++ b/ui/src/style/components/view/resource-context-menu.less
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 .resource-context-menu {
   position: fixed;
   z-index: 2000;

--- a/ui/src/style/index.less
+++ b/ui/src/style/index.less
@@ -37,6 +37,31 @@
 @import "frame/top-menu";
 
 @import "objects/table";
+
+.sider .ant-layout-sider-children,
+.sider .ant-menu,
+.sider .ant-menu-root,
+.drawer-sider .ant-layout-sider-children,
+.drawer-sider .ant-menu,
+.drawer-sider .ant-menu-root,
+.sticky-sidebar .sider .ant-layout-sider-children,
+.sticky-sidebar .sider .ant-menu,
+.sticky-sidebar .sider .ant-menu-root {
+  max-width: 100%;
+  overflow-x: hidden;
+  scrollbar-width: thin;
+}
+
+.sider .ant-layout-sider-children::-webkit-scrollbar,
+.sider .ant-menu::-webkit-scrollbar,
+.sider .ant-menu-root::-webkit-scrollbar,
+.sticky-sidebar .sider .ant-layout-sider-children::-webkit-scrollbar,
+.sticky-sidebar .sider .ant-menu::-webkit-scrollbar,
+.sticky-sidebar .sider .ant-menu-root::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
 @import "dark-mode";
 @import "theme/tokens";
 @import "theme/base";

--- a/ui/src/style/theme/base.less
+++ b/ui/src/style/theme/base.less
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 html,
 body,
 #app {

--- a/ui/src/style/theme/components.less
+++ b/ui/src/style/theme/components.less
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 body {
   .ant-layout,
   .ant-layout-content,

--- a/ui/src/style/theme/feedback.less
+++ b/ui/src/style/theme/feedback.less
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 body {
   .ant-alert,
   .ant-message-notice-content,

--- a/ui/src/style/theme/scrollbar.less
+++ b/ui/src/style/theme/scrollbar.less
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 html {
   scrollbar-gutter: stable;
 }

--- a/ui/src/style/theme/tokens.less
+++ b/ui/src/style/theme/tokens.less
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 /* Theme semantic tokens shared by light and dark modes. */
 
 :root {

--- a/ui/src/views/infra/zone/RackDiagramTab.vue
+++ b/ui/src/views/infra/zone/RackDiagramTab.vue
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 <template>
   <div class="p-2 rack-diagram-root" :class="{ 'is-dark': isDarkMode }">
     <div class="toolbar-container" :class="{ 'toolbar-detail': !showRackList }">

--- a/ui/tests/unit/components/header/ActivityNavigation.spec.js
+++ b/ui/tests/unit/components/header/ActivityNavigation.spec.js
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { shallowMount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { createStore } from 'vuex'
+
+import HeaderNotice from '@/components/header/HeaderNotice.vue'
+import Drawer from '@/components/widgets/Drawer.vue'
+
+const createI18nPlugin = () => createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} }
+})
+
+describe('Components > Header > activity navigation', () => {
+  it('opens the activity panel and closes the notification popover', () => {
+    const store = createStore({
+      getters: {
+        apis: () => ({ listEvents: {}, listAlerts: {} }),
+        headerNotices: () => []
+      }
+    })
+    const wrapper = shallowMount(HeaderNotice, {
+      global: { plugins: [store, createI18nPlugin()] }
+    })
+
+    wrapper.vm.visible = true
+    wrapper.vm.openActivityPanel()
+
+    expect(wrapper.vm.visible).toBe(false)
+    expect(wrapper.emitted('open-activity-panel')).toHaveLength(1)
+  })
+
+  it('does not offer the activity panel without event or alert APIs', () => {
+    const store = createStore({
+      getters: {
+        apis: () => ({}),
+        headerNotices: () => []
+      }
+    })
+    const wrapper = shallowMount(HeaderNotice, {
+      global: { plugins: [store, createI18nPlugin()] }
+    })
+
+    expect(wrapper.vm.canOpenActivityPanel).toBe(false)
+  })
+})
+
+describe('Components > Widgets > Drawer.vue', () => {
+  it('hides the fixed handler and keeps an internal close action', async () => {
+    const close = jest.fn()
+    const wrapper = shallowMount(Drawer, {
+      props: {
+        visible: true,
+        showHandler: false,
+        title: 'Display settings'
+      },
+      global: {
+        plugins: [createI18nPlugin()],
+        provide: { parentToggleSetting: close },
+        stubs: {
+          'a-button': { template: '<button @click="$emit(\'click\', $event)"><slot /></button>' },
+          'close-outlined': true
+        }
+      }
+    })
+
+    expect(wrapper.find('.handler-container').exists()).toBe(false)
+    expect(wrapper.find('.drawer-header').exists()).toBe(true)
+
+    await wrapper.find('.drawer-header button').trigger('click')
+    expect(close).toHaveBeenCalledWith(false)
+  })
+})

--- a/ui/tests/unit/components/view/ActionButton.spec.js
+++ b/ui/tests/unit/components/view/ActionButton.spec.js
@@ -126,6 +126,27 @@ describe('Components > View > ActionButton.vue', () => {
 
       expect(received).toContain(expected)
     })
+
+    it('wraps data view icons in a fixed alignment slot', () => {
+      const wrapper = factory({
+        props: {
+          actions: [{
+            label: 'label.action',
+            api: 'test-api-case-2',
+            icon: ['fas', 'camera-retro'],
+            dataView: true
+          }],
+          dataView: true,
+          resource: {
+            id: 'test-resource-id'
+          }
+        }
+      })
+
+      const iconSlot = wrapper.find('.resource-action-menu__item-icon')
+      expect(iconSlot.exists()).toBe(true)
+      expect(iconSlot.attributes('aria-hidden')).toBe('true')
+    })
   })
 
   describe('Method', () => {

--- a/ui/tests/unit/components/view/ActionButton.spec.js
+++ b/ui/tests/unit/components/view/ActionButton.spec.js
@@ -150,6 +150,37 @@ describe('Components > View > ActionButton.vue', () => {
   })
 
   describe('Method', () => {
+    describe('openConsole()', () => {
+      it('uses an external console URL without requesting a console endpoint', () => {
+        const externalUrl = 'https://console.example.test/session'
+        const openSpy = jest.spyOn(window, 'open').mockImplementation(() => {})
+        const wrapper = factory({
+          props: {
+            resource: {
+              id: 'test-resource-id',
+              details: {
+                'External:console_url': externalUrl
+              }
+            }
+          }
+        })
+
+        wrapper.vm.openConsole(false)
+
+        expect(openSpy).toHaveBeenCalledWith(externalUrl, '_blank')
+        expect(mockAxios).not.toHaveBeenCalled()
+        openSpy.mockRestore()
+      })
+
+      it('falls back to the route name when route metadata has no name', () => {
+        const routeName = ActionButton.computed.routeName.call({
+          $route: { meta: {}, name: 'host' }
+        })
+
+        expect(routeName).toBe('host')
+      })
+    })
+
     describe('handleShowBadge()', () => {
       it('API should be called and return not empty', async (done) => {
         const postData = new URLSearchParams()

--- a/ui/tests/unit/components/view/EventSidebar.spec.js
+++ b/ui/tests/unit/components/view/EventSidebar.spec.js
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { flushPromises, shallowMount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { createStore } from 'vuex'
+
+import EventSidebar from '@/components/view/EventSidebar.vue'
+import { getAPI } from '@/api'
+
+jest.mock('@/api', () => ({
+  getAPI: jest.fn()
+}))
+
+const factory = (props = {}) => {
+  const store = createStore({
+    getters: {
+      apis: () => ({ listEvents: {}, listAlerts: {} }),
+      userInfo: () => ({ roletype: 'User' })
+    }
+  })
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: {} }
+  })
+
+  return shallowMount(EventSidebar, {
+    props: { isVisible: false, ...props },
+    global: {
+      plugins: [store, i18n],
+      stubs: {
+        'a-button': { template: '<button><slot /></button>' },
+        'a-table': true,
+        'close-outlined': true,
+        'down-outlined': true,
+        'up-outlined': true
+      }
+    }
+  })
+}
+
+describe('Components > View > EventSidebar.vue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    window.localStorage.clear()
+  })
+
+  it('renders event and alert tabs without an overlay drawer', () => {
+    const wrapper = factory()
+
+    expect(wrapper.find('.bottom-activity-panel').exists()).toBe(true)
+    expect(wrapper.findAll('.bottom-activity-panel__tab')).toHaveLength(2)
+    expect(wrapper.find('a-drawer-stub').exists()).toBe(false)
+  })
+
+  it('shows the correct visible icon for collapsing and restoring the panel', async () => {
+    const wrapper = factory()
+
+    expect(wrapper.find('down-outlined-stub').exists()).toBe(true)
+    expect(wrapper.find('up-outlined-stub').exists()).toBe(false)
+
+    wrapper.vm.toggleCollapsed()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('down-outlined-stub').exists()).toBe(false)
+    expect(wrapper.find('up-outlined-stub').exists()).toBe(true)
+  })
+
+  it('loads existing alert data when the alert tab is selected', async () => {
+    getAPI.mockResolvedValue({
+      listalertsresponse: {
+        alert: [{ id: 'alert-1', name: 'Test alert' }]
+      }
+    })
+    const wrapper = factory()
+
+    wrapper.vm.selectTab('alerts')
+    await flushPromises()
+
+    expect(getAPI).toHaveBeenCalledWith('listAlerts', {
+      page: 1,
+      pagesize: 20,
+      listall: true
+    })
+    expect(wrapper.vm.alerts).toEqual([{ id: 'alert-1', name: 'Test alert' }])
+  })
+
+  it('clamps and persists keyboard resizing', () => {
+    const wrapper = factory()
+    const preventDefault = jest.fn()
+
+    wrapper.vm.expandedHeight = wrapper.vm.maxHeight
+    wrapper.vm.onResizeKeydown({ key: 'ArrowUp', shiftKey: false, preventDefault })
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(wrapper.vm.expandedHeight).toBe(wrapper.vm.maxHeight)
+    expect(window.localStorage.getItem('ablestack.bottomActivityPanel.height.v1'))
+      .toBe(String(wrapper.vm.maxHeight))
+  })
+
+  it('keeps only events inside the configured recent window', () => {
+    const wrapper = factory()
+    const now = Date.now()
+    const events = [
+      { id: 'recent', created: new Date(now - 1000).toISOString() },
+      { id: 'old', created: new Date(now - 600000).toISOString() }
+    ]
+
+    expect(wrapper.vm.filterRecentEvents(events, 60000).map(event => event.id))
+      .toEqual(['recent'])
+  })
+})

--- a/ui/tests/unit/components/view/EventSidebar.spec.js
+++ b/ui/tests/unit/components/view/EventSidebar.spec.js
@@ -20,10 +20,10 @@ import { createI18n } from 'vue-i18n'
 import { createStore } from 'vuex'
 
 import EventSidebar from '@/components/view/EventSidebar.vue'
-import { getAPI } from '@/api'
+import { api } from '@/api'
 
 jest.mock('@/api', () => ({
-  getAPI: jest.fn()
+  api: jest.fn()
 }))
 
 const factory = (props = {}) => {
@@ -82,7 +82,7 @@ describe('Components > View > EventSidebar.vue', () => {
   })
 
   it('loads existing alert data when the alert tab is selected', async () => {
-    getAPI.mockResolvedValue({
+    api.mockResolvedValue({
       listalertsresponse: {
         alert: [{ id: 'alert-1', name: 'Test alert' }]
       }
@@ -92,7 +92,7 @@ describe('Components > View > EventSidebar.vue', () => {
     wrapper.vm.selectTab('alerts')
     await flushPromises()
 
-    expect(getAPI).toHaveBeenCalledWith('listAlerts', {
+    expect(api).toHaveBeenCalledWith('listAlerts', {
       page: 1,
       pagesize: 20,
       listall: true


### PR DESCRIPTION
## 변경 목적

Diplo UI의 전역 레이아웃, 최근 이벤트 및 경고 표시, 사용자 메뉴, 액션 메뉴와 라이트/다크 테마 후속 개선을 반영합니다.

## 주요 변경 사항

- 최근 이벤트와 경고 표시 레이어 및 활동 패널 동작 개선
- UI 모드 변경 영역과 사용자 메뉴 배치 정리
- 리소스 액션 및 컨텍스트 메뉴의 가독성과 위치 일관성 개선
- 라이트/다크 테마 토큰, 피드백 배너, 스크롤바 스타일 보완
- 전역 레이아웃과 Drawer 동작 및 표시 일관성 개선
- 관련 단위 테스트 추가 및 보강

## 검증 결과

- `ActivityNavigation.spec.js`, `ActionButton.spec.js`, `EventSidebar.spec.js`: 3개 스위트, 21개 테스트 통과
- `npm run build`: 프로덕션 UI 빌드 성공
- 변경 범위가 UI 및 관련 테스트로 제한됨을 확인

## 반영 순서

스토리지 서비스 변경이 반영된 `ablestack-diplo` 최신 커밋을 기반으로 하며, 본 PR 병합 후 후속 SharedFS 안정화 브랜치를 최신 base로 갱신합니다.
