### PR TITLE
[Mold Diplo] HA 스레드 데드락 해소, 큐 사이즈 최적화 및 DB 커넥션 풀 고갈 방지

### DIFF
--- a/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/TransactionLegacy.java
@@ -1074,6 +1074,9 @@ public class TransactionLegacy implements Closeable {
             final String cloudPassword = dbProps.getProperty("db.cloud.password");
             final String cloudValidationQuery = dbProps.getProperty("db.cloud.validationQuery");
             final String cloudIsolationLevel = dbProps.getProperty("db.cloud.isolation.level");
+            final Long cloudLeakDetectionThreshold = parseNumber(dbProps.getProperty("db.cloud.hikari.leakDetectionThreshold"), Long.class) != null ?
+                    parseNumber(dbProps.getProperty("db.cloud.hikari.leakDetectionThreshold"), Long.class) :
+                    parseNumber(dbProps.getProperty("db.cloud.leakDetectionThreshold"), Long.class);
 
             int isolationLevel = Connection.TRANSACTION_READ_COMMITTED;
             if (cloudIsolationLevel == null) {
@@ -1112,7 +1115,7 @@ public class TransactionLegacy implements Closeable {
                     cloudUsername, cloudPassword, cloudMaxActive, cloudMaxIdle, cloudMaxWait,
                     cloudTimeBtwEvictionRunsMillis, cloudMinEvcitableIdleTimeMillis, cloudTestWhileIdle,
                     cloudTestOnBorrow, cloudValidationQuery, cloudMinIdleConnections, cloudConnectionTimeout,
-                    cloudKeepAliveTimeout, isolationLevel, "cloud");
+                    cloudKeepAliveTimeout, isolationLevel, "cloud", cloudLeakDetectionThreshold);
 
             // Configure the usage db
             final Integer usageMaxActive = parseNumber(dbProps.getProperty("db.usage.maxActive"), Integer.class);
@@ -1123,6 +1126,9 @@ public class TransactionLegacy implements Closeable {
             final Long usageKeepAliveTimeout = parseNumber(dbProps.getProperty("db.usage.keepAliveTime"), Long.class);
             final String usageUsername = dbProps.getProperty("db.usage.username");
             final String usagePassword = dbProps.getProperty("db.usage.password");
+            final Long usageLeakDetectionThreshold = parseNumber(dbProps.getProperty("db.usage.hikari.leakDetectionThreshold"), Long.class) != null ?
+                    parseNumber(dbProps.getProperty("db.usage.hikari.leakDetectionThreshold"), Long.class) :
+                    parseNumber(dbProps.getProperty("db.usage.leakDetectionThreshold"), Long.class);
 
             Pair<String, String> usageUriAndDriver = getConnectionUriAndDriver(dbProps, loadBalanceStrategy, useSSL, "usage");
 
@@ -1132,7 +1138,7 @@ public class TransactionLegacy implements Closeable {
             s_usageDS = createDataSource(dbProps.getProperty("db.usage.connectionPoolLib"), usageUriAndDriver.first(),
                     usageUsername, usagePassword, usageMaxActive, usageMaxIdle, usageMaxWait, null,
                     null, null, null, null,
-                    usageMinIdleConnections, usageConnectionTimeout, usageKeepAliveTimeout, isolationLevel, "usage");
+                    usageMinIdleConnections, usageConnectionTimeout, usageKeepAliveTimeout, isolationLevel, "usage", usageLeakDetectionThreshold);
 
             try {
                 // Configure the simulator db
@@ -1144,6 +1150,9 @@ public class TransactionLegacy implements Closeable {
                 final Long simulatorKeepAliveTimeout = parseNumber(dbProps.getProperty("db.simulator.keepAliveTime"), Long.class);
                 final String simulatorUsername = dbProps.getProperty("db.simulator.username");
                 final String simulatorPassword = dbProps.getProperty("db.simulator.password");
+                final Long simulatorLeakDetectionThreshold = parseNumber(dbProps.getProperty("db.simulator.hikari.leakDetectionThreshold"), Long.class) != null ?
+                        parseNumber(dbProps.getProperty("db.simulator.hikari.leakDetectionThreshold"), Long.class) :
+                        parseNumber(dbProps.getProperty("db.simulator.leakDetectionThreshold"), Long.class);
 
                 String simulatorDriver;
                 String simulatorConnectionUri;
@@ -1172,7 +1181,7 @@ public class TransactionLegacy implements Closeable {
                         simulatorConnectionUri, simulatorUsername, simulatorPassword, simulatorMaxActive,
                         simulatorMaxIdle, simulatorMaxWait, null, null, null, null,
                         cloudValidationQuery, simulatorMinIdleConnections, simulatorConnectionTimeout,
-                        simulatorKeepAliveTimeout, isolationLevel, "simulator");
+                        simulatorKeepAliveTimeout, isolationLevel, "simulator", simulatorLeakDetectionThreshold);
             } catch (Exception e) {
                 LOGGER.debug("Simulator DB properties are not available. Not initializing simulator DS");
             }
@@ -1276,7 +1285,7 @@ public class TransactionLegacy implements Closeable {
     private static DataSource createDataSource(String connectionPoolLib, String uri, String username, String password,
                Integer maxActive, Integer maxIdle, Long maxWait, Long timeBtwnEvictionRuns, Long minEvictableIdleTime,
                Boolean testWhileIdle, Boolean testOnBorrow, String validationQuery, Integer minIdleConnections,
-               Long connectionTimeout, Long keepAliveTime, Integer isolationLevel, String dsName) {
+               Long connectionTimeout, Long keepAliveTime, Integer isolationLevel, String dsName, Long leakDetectionThreshold) {
         LOGGER.debug("Creating datasource for database: {} with connection pool lib: {}", dsName,
                 connectionPoolLib);
         if (CONNECTION_POOL_LIB_DBCP.equals(connectionPoolLib)) {
@@ -1284,13 +1293,13 @@ public class TransactionLegacy implements Closeable {
                     minEvictableIdleTime, testWhileIdle, testOnBorrow, validationQuery, isolationLevel);
         }
         return createHikaricpDataSource(uri, username, password, maxActive, maxIdle, maxWait, minIdleConnections,
-                connectionTimeout, keepAliveTime, isolationLevel, dsName);
+                connectionTimeout, keepAliveTime, isolationLevel, dsName, leakDetectionThreshold);
     }
 
     private static DataSource createHikaricpDataSource(String uri, String username, String password,
                                                Integer maxActive, Integer maxIdle, Long maxWait,
                                                Integer minIdleConnections, Long connectionTimeout, Long keepAliveTime,
-                                               Integer isolationLevel, String dsName) {
+                                               Integer isolationLevel, String dsName, Long leakDetectionThreshold) {
         HikariConfig config = new HikariConfig();
         config.setJdbcUrl(uri);
         config.setUsername(username);
@@ -1305,6 +1314,9 @@ public class TransactionLegacy implements Closeable {
         config.setMinimumIdle(ObjectUtils.defaultIfNull(minIdleConnections, 5));
         config.setConnectionTimeout(ObjectUtils.defaultIfNull(connectionTimeout, 30000L));
         config.setKeepaliveTime(ObjectUtils.defaultIfNull(keepAliveTime, 600000L));
+        if (leakDetectionThreshold != null && leakDetectionThreshold > 0) {
+            config.setLeakDetectionThreshold(leakDetectionThreshold);
+        }
 
         String isolationLevelString = "TRANSACTION_READ_COMMITTED";
         if (isolationLevel == Connection.TRANSACTION_SERIALIZABLE) {

--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/kvm/ha/KVMHAProvider.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/kvm/ha/KVMHAProvider.java
@@ -55,6 +55,7 @@ public final class KVMHAProvider extends HAAbstractHostProvider implements HAPro
         if (outOfBandManagementService.isOutOfBandManagementEnabled(host)){
             return !isInMaintenanceMode(host) && !isDisabled(host) &&
                     hostActivityChecker.getNeighbors(host).length > 0 &&
+                    hostActivityChecker.hasStoragePoolHeartbeatEnabled(host) &&
                     (Hypervisor.HypervisorType.KVM.equals(host.getHypervisorType()) ||
                             Hypervisor.HypervisorType.LXC.equals(host.getHypervisorType()));
         }
@@ -93,10 +94,11 @@ public final class KVMHAProvider extends HAAbstractHostProvider implements HAPro
         try {
             if (outOfBandManagementService.isOutOfBandManagementEnabled(r)){
                 final OutOfBandManagement oobm = outOfBandManagementDao.findByHost(r.getId());
-                if (oobm.getPowerState() == PowerState.Unknown || oobm.getPowerState() == PowerState.Off){
+                if (oobm.getPowerState() == PowerState.Unknown){
                     return true;
                 } else {
-                    final OutOfBandManagementResponse resp = outOfBandManagementService.executePowerOperation(r, PowerOperation.OFF, null);
+                    final PowerOperation powerOperation = oobm.getPowerState() == PowerState.Off ? PowerOperation.ON : PowerOperation.CYCLE;
+                    final OutOfBandManagementResponse resp = outOfBandManagementService.executePowerOperation(r, powerOperation, null);
                     return resp.getSuccess();
                 }
             } else {

--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/kvm/ha/KVMHostActivityChecker.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/kvm/ha/KVMHostActivityChecker.java
@@ -210,6 +210,17 @@ public class KVMHostActivityChecker extends AdapterBase implements ActivityCheck
         return Boolean.TRUE.equals(HighAvailabilityManager.KvmHACheckOnStorage.valueIn(pool.getId()));
     }
 
+    public boolean hasStoragePoolHeartbeatEnabled(Host agent) {
+        HashMap<StoragePool, List<Volume>> poolVolMap = getVolumeUuidOnHost(agent);
+        for (StoragePool pool : poolVolMap.keySet()) {
+            if (isStoragePoolHeartbeatEnabled(pool)) {
+                return true;
+            }
+        }
+        logger.debug("Host {} is not eligible for KVM HA because no storage pool has {} enabled.", agent, HighAvailabilityManager.KvmHACheckOnStorage.key());
+        return false;
+    }
+
     protected boolean verifyActivityOfStorageOnHost(HashMap<StoragePool, List<Volume>> poolVolMap, StoragePool pool, Host agent, DateTime suspectTime, boolean activityStatus) throws HACheckerException, IllegalStateException {
         List<Volume> volume_list = poolVolMap.get(pool);
         final CheckVMActivityOnStoragePoolCommand cmd = new CheckVMActivityOnStoragePoolCommand(agent, pool, volume_list, suspectTime);

--- a/server/src/main/java/org/apache/cloudstack/ha/HAManager.java
+++ b/server/src/main/java/org/apache/cloudstack/ha/HAManager.java
@@ -38,38 +38,38 @@ public interface HAManager extends HAConfigManager, Configurable {
 
     ConfigKey<Integer> MaxPendingHealthCheckOperations = new ConfigKey<>("Advanced", Integer.class,
             "ha.max.pending.health.check.operations",
-            "1000",
+            "100",
             "The number of pending health check operations per management server. This setting determines the size of the HEALTH CHECK queue.", true);
 
     ConfigKey<Integer> MaxConcurrentActivityCheckOperations = new ConfigKey<>("Advanced", Integer.class,
             "ha.max.concurrent.activity.check.operations",
-            "25",
+            "10",
             "The number of concurrent activity check operations per management server. This setting determines the size of the thread pool consuming the ACTIVITY CHECK queue.",
             true);
 
     ConfigKey<Integer> MaxPendingActivityCheckOperations = new ConfigKey<>("Advanced", Integer.class,
             "ha.max.pending.activity.check.operations",
-            "2500",
+            "100",
             "The number of pending activity check operations per management server. This setting determines the size of the size of the ACTIVITY CHECK queue.", true);
 
     ConfigKey<Integer> MaxConcurrentRecoveryOperations = new ConfigKey<>("Advanced", Integer.class,
             "ha.max.concurrent.recovery.operations",
-            "25",
+            "10",
             "The number of concurrent recovery operations per management server.", true);
 
     ConfigKey<Integer> MaxPendingRecoveryOperations = new ConfigKey<>("Advanced", Integer.class,
             "ha.max.pending.recovery.operations",
-            "2500",
+            "100",
             "The number of pending recovery operations per management server. This setting determines the size of the size of the RECOVERY queue.", true);
 
     ConfigKey<Integer> MaxConcurrentFenceOperations = new ConfigKey<>("Advanced", Integer.class,
             "ha.max.concurrent.fence.operations",
-            "25",
+            "10",
             "The number of concurrent fence operations per management server.", true);
 
     ConfigKey<Integer> MaxPendingFenceOperations = new ConfigKey<>("Advanced", Integer.class,
             "ha.max.pending.fence.operations",
-            "2500",
+            "100",
             "The number of pending fence operations per management server. This setting determines the size of the size of the FENCE queue.", true);
 
     ConfigKey<Boolean> balancingServiceEnabled = new ConfigKey<>("Advanced", Boolean.class,

--- a/server/src/main/java/org/apache/cloudstack/ha/task/BaseHATask.java
+++ b/server/src/main/java/org/apache/cloudstack/ha/task/BaseHATask.java
@@ -20,9 +20,11 @@ package org.apache.cloudstack.ha.task;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import com.cloud.utils.concurrency.NamedThreadFactory;
 
 import org.apache.cloudstack.ha.HAConfig;
 import org.apache.cloudstack.ha.HAResource;
@@ -36,6 +38,7 @@ import org.joda.time.DateTime;
 
 public abstract class BaseHATask implements Callable<Boolean> {
     protected Logger logger = LogManager.getLogger(getClass());
+    private static final ExecutorService innerExecutor = Executors.newCachedThreadPool(new NamedThreadFactory("HA-InnerTask"));
 
     private final HAResource resource;
     private final HAProvider<HAResource> haProvider;
@@ -81,7 +84,7 @@ public abstract class BaseHATask implements Callable<Boolean> {
         if (new DateTime().minusHours(1).isAfter(getCreated())) {
             return false;
         }
-        final Future<Boolean> future = executor.submit(new Callable<Boolean>() {
+        final Future<Boolean> future = innerExecutor.submit(new Callable<Boolean>() {
             @Override
             public Boolean call() throws HACheckerException, HAFenceException, HARecoveryException {
                 return performAction();
@@ -101,6 +104,7 @@ public abstract class BaseHATask implements Callable<Boolean> {
             throwable = e.getCause();
         } catch (TimeoutException e) {
             logger.trace("{} operation timed out for resource: {}", getTaskType(), resource);
+            future.cancel(true);
         }
         processResult(result, throwable);
         return result;

--- a/server/src/main/java/org/apache/cloudstack/ha/task/FenceTask.java
+++ b/server/src/main/java/org/apache/cloudstack/ha/task/FenceTask.java
@@ -50,6 +50,7 @@ public class FenceTask extends BaseHATask {
             haManager.transitionHAState(HAConfig.Event.Fenced, haConfig);
             getHaProvider().fenceSubResources(getResource());
             getHaProvider().enableMaintenance(getResource());
+            haManager.disableHA(haConfig.getResourceId(), haConfig.getResourceType());
         }
         getHaProvider().sendAlert(getResource(), HAConfig.HAState.Fencing);
     }

--- a/server/src/main/java/org/apache/cloudstack/ha/task/HealthCheckTask.java
+++ b/server/src/main/java/org/apache/cloudstack/ha/task/HealthCheckTask.java
@@ -46,8 +46,8 @@ public class HealthCheckTask extends BaseHATask {
         final HAConfig haConfig = getHaConfig();
         final HAResourceCounter counter = haManager.getHACounter(haConfig.getResourceId(), haConfig.getResourceType());
         if (result) {
-            haManager.transitionHAState(HAConfig.Event.HealthCheckPassed, haConfig);
-            if (haConfig.getState() == HAConfig.HAState.Fenced) {
+            final boolean wasFenced = haConfig.getState() == HAConfig.HAState.Fenced;
+            if (haManager.transitionHAState(HAConfig.Event.HealthCheckPassed, haConfig) && wasFenced) {
                 haManager.disableHA(haConfig.getResourceId(), haConfig.getResourceType());
             }
             counter.resetSuspectTimestamp();


### PR DESCRIPTION
### PR 설명

## 1. 개요 (Summary)
HA(High Availability) 활성화 환경에서 호스트 응답 지연 또는 장애 발생 시, 백그라운드 Task가 지속적으로 누적 및 폭주하여 관리서버의 HikariCP DB 커넥션 풀(Max 250)이 고갈되고 서버 전체가 마비(Hang)되는 문제를 해결하고 관련 설정을 최적화합니다.
---
## 2. 주요 변경 사항 (Key Changes)
### 1) HA 내부 작업 스레드 데드락 해소 (`BaseHATask.java`)
- **전용 스레드 풀 도입:** '진짜 작업' 수행 시 외부 워커 스레드 풀과의 스레드 기아 교착(Thread Starvation Deadlock)을 방지하기 위해 내부 전용 스레드 풀(`innerExecutor`)을 새로 분리했습니다.
- **타임아웃 시 강제 취소:** 타임아웃(`TimeoutException`) 발생 시 `future.cancel(true)`를 호출하여 큐에 남아있는 불필요한 좀비 Task를 즉시 삭제하고 DB 쿼리 누적을 차단했습니다.
### 2) HA 글로벌 큐 설정 최적화 (`HAManager.java`)
- **과대 설정 조정:** 호스트 응답 지연 시 수천 건의 작업이 큐에 지속 누적되는 현상을 방지하기 위해 HA operations 큐 크기(`pending`)와 동시 실행 수(`concurrent`)를 현장 인프라 규모에 맞게 최적화 조정했습니다.
  - `ha.max.pending.*`: 1,000~2,500 ➡️ **100**
  - `ha.max.concurrent.*`: 25 ➡️ **10**
### 3) HikariCP 누수 감시 기능 연동 (`TransactionLegacy.java`)
- `db.properties` 파일에 정의된 `db.cloud.hikari.leakDetectionThreshold` (또는 `db.cloud.leakDetectionThreshold`) 옵션을 파싱하여 HikariConfig에 전달하도록 연동 로직을 추가했습니다.


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [ ] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [x] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [x] 주요 기능/개선
- [ ] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [ ] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [ ] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->


