### PR TITLE
Diplo SharedFS 생성 및 런타임 정합성 안정화

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/storage/dataservice/StorageServiceInstance.java
+++ b/api/src/main/java/org/apache/cloudstack/storage/dataservice/StorageServiceInstance.java
@@ -23,20 +23,15 @@ import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.api.Identity;
 import org.apache.cloudstack.api.InternalIdentity;
 import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.storage.sharedfs.SharedFS;
 
 public interface StorageServiceInstance extends ControlledEntity, Identity, InternalIdentity {
-    ConfigKey<Boolean> StorageServiceFeatureEnabled = new ConfigKey<Boolean>("Advanced", Boolean.class,
-            "storage.service.feature.enabled",
-            "false",
-            "Indicates whether the System VM based Storage Service feature is enabled or not. Management server restart needed on change.",
-            false);
-
     ConfigKey<Integer> StorageServiceCommandTimeout = new ConfigKey<Integer>("Advanced", Integer.class,
             "storage.service.command.timeout",
             "300",
             "Timeout in seconds for a Storage Service host-agent/QGA command.",
             true,
-            StorageServiceFeatureEnabled.key());
+            SharedFS.SharedFSFeatureEnabled.key());
 
     String StorageServiceVmType = "storageservicevm";
     String StorageServiceProviderName = "STORAGESERVICEVM";

--- a/docs/design/diplo-sharedfs-create-request-stability.md
+++ b/docs/design/diplo-sharedfs-create-request-stability.md
@@ -1,0 +1,41 @@
+# Diplo SharedFS 생성 요청 안정화 설계
+
+## 배경
+
+Diplo 공유 파일시스템 생성 화면은 일반 디스크 오퍼링을 선택해 IOPS 입력란이 없는 경우에도 `miniops`와 `maxiops`를 요청 객체에 포함했다. 공통 API 직렬화기는 JavaScript의 `undefined`를 문자열 `"undefined"`로 전송했고, 관리 서버는 LONG 파라미터를 해석하는 단계에서 요청을 거부했다.
+
+## 설계 원칙
+
+| 계층 | AS-IS | TO-BE |
+|---|---|---|
+| 생성 화면 | 디스크 오퍼링 종류와 관계없이 IOPS 필드 포함 | 사용자 지정 IOPS 오퍼링이며 두 값이 모두 입력된 경우에만 포함 |
+| 입력 상태 | 오퍼링 변경 후 숨겨진 IOPS 값이 남을 수 있음 | 일반 오퍼링으로 변경하면 두 값을 즉시 초기화 |
+| 입력 검증 | 각 값의 양수 여부만 독립 검사 | 둘 다 입력하거나 둘 다 생략, 양의 정수, 최소값 이하 최대값 규칙 적용 |
+| API 직렬화 | `undefined`와 `null`도 문자열로 직렬화 | 부재 값은 전송하지 않고 `0`, `false`, 빈 문자열은 기존 의미를 보존 |
+| 서버 검증 | 사용자 지정 IOPS 지원 여부만 검사 | 쌍 입력, 양수, `miniops <= maxiops`를 최종 검증 |
+
+## 코드 반영 대상
+
+- `ui/src/views/storage/CreateSharedFS.vue`
+  - `buildCreateSharedFsRequest`에서 생성 요청을 단일 경로로 조립한다.
+  - IOPS는 사용자 지정 IOPS 오퍼링과 완전한 값 쌍을 만족할 때만 숫자로 전송한다.
+  - 오퍼링 전환 시 숨겨진 IOPS 상태를 제거한다.
+- `ui/src/api/index.js`
+  - `appendApiData`를 통해 `undefined`와 `null`을 모든 POST 요청에서 제외한다.
+- `server/src/main/java/org/apache/cloudstack/storage/sharedfs/SharedFSServiceImpl.java`
+  - UI 우회 호출에도 동일한 IOPS 계약을 적용한다.
+- 단위 테스트
+  - 공통 직렬화의 부재 값 제거와 의미 있는 falsy 값 보존을 검증한다.
+  - SharedFS 생성 요청의 일반/사용자 지정 IOPS 분기를 검증한다.
+  - 서버의 불완전, 비양수, 역전 IOPS 범위를 검증한다.
+
+## 배포 및 확인 기준
+
+1. UI와 관리 서버 변경 산출물만 배포한다.
+2. 기존 런타임 `config.json`을 보존한다.
+3. `/usr/share/cloudstack-ui`는 정적 UI 산출물로 교체할 수 있지만, `/usr/share/cloudstack-management/webapp`은 `WEB-INF`를 포함하는 서버 웹앱이므로 기존 디렉터리에 정적 산출물만 덮어쓴다.
+4. 배포 후 `WEB-INF/web.xml`, `/client/api/` 라우팅과 인증 응답을 먼저 확인한다.
+5. 배포된 `index.html`의 JS/CSS 해시와 HTTP 200 응답을 확인한다.
+6. 일반 디스크 오퍼링 생성 요청에 `miniops`, `maxiops`, `undefined`가 없음을 확인한다.
+7. 관리 서버 로그에서 LONG 파라미터 변환 오류가 재발하지 않아야 한다.
+8. DB 스키마와 SystemVM 템플릿은 변경하지 않는다.

--- a/docs/design/diplo-sharedfs-single-feature-gate.md
+++ b/docs/design/diplo-sharedfs-single-feature-gate.md
@@ -1,0 +1,51 @@
+# Diplo SharedFS 단일 기능 플래그 설계
+
+## 목적
+
+Diplo의 Shared FileSystem과 Storage Service 기능은 하나의 제품 기능이다. 따라서 `sharedfs.feature.enabled`만을 기능 노출과 런타임 동작의 기준으로 사용하고, 별도 `storage.service.feature.enabled` 설정은 제거한다.
+
+## 문제
+
+| 구분 | AS-IS | 영향 |
+| --- | --- | --- |
+| 기능 플래그 | SharedFS와 Storage Service가 서로 다른 플래그를 사용 | 메뉴는 표시되지만 Storage Service 모델 생성은 생략될 수 있음 |
+| 생성 완료 | SharedFS VM과 볼륨은 생성되지만 `storage_service_instance`가 없을 수 있음 | UI 초기 서비스 구성이 인스턴스를 찾지 못하고 실패 |
+| 기존 데이터 | 플래그가 꺼진 동안 생성된 SharedFS를 자동 보정하지 않음 | 설정을 바꿔도 기존 서비스는 계속 불완전 |
+| DB 설정 | 폐기 대상 설정이 `configuration`에 남음 | 운영자가 의미 없는 이중 설정을 관리하게 됨 |
+
+## TO-BE
+
+1. `sharedfs.feature.enabled=true`
+   - SharedFS API와 Storage Service API를 함께 등록한다.
+   - SharedFS 생성 및 수명주기 변경 시 Storage Service 호환 모델을 항상 동기화한다.
+   - NFS, SMB, iSCSI, NVMe-oF 탭과 작업 API를 사용할 수 있다.
+2. `sharedfs.feature.enabled=false`
+   - SharedFS API와 Storage Service API를 모두 등록하지 않는다.
+   - API 권한을 기준으로 구성되는 SharedFS 메뉴도 UI에서 숨겨진다.
+   - 관리 서버 재시작 후 적용한다.
+3. 관리 서버 시작 시 보정
+   - VM과 데이터 볼륨이 연결된 비삭제 SharedFS를 조회한다.
+   - `storage_service_instance`와 기본 NFS 프로토콜 모델을 idempotent하게 생성 또는 갱신한다.
+   - Destroyed, Expunging, Expunged 및 연결 정보가 불완전한 레코드는 제외한다.
+4. 설치 및 업데이트
+   - `storage.service.feature.enabled` ConfigKey를 소스에서 제거한다.
+   - Diplo 후처리 스키마에서 기존 `configuration` 행을 삭제한다.
+   - `storage.service.command.timeout`의 상위 기능 키는 `sharedfs.feature.enabled`로 변경한다.
+
+## 코드 변경 대상
+
+| 구성요소 | 파일 | 변경 |
+| --- | --- | --- |
+| API 설정 | `api/.../StorageServiceInstance.java` | 별도 기능 키 제거, 명령 타임아웃의 SharedFS 종속성 설정 |
+| SharedFS 수명주기 | `server/.../SharedFSServiceImpl.java` | 단일 플래그 사용, 관리 서버 시작 시 기존 모델 보정 |
+| Storage Service API | `server/.../StorageServiceManagerImpl.java` | SharedFS 플래그가 꺼지면 명령 목록을 등록하지 않음 |
+| DB 업데이트 | `engine/schema/.../schema-Diplo-After.sql` | 폐기 설정 행을 idempotent하게 삭제 |
+| 테스트 | `server/src/test/...` | 보정 대상 판정 및 설정 종속성 검증 |
+
+## 검증 기준
+
+- 소스 전체에서 `storage.service.feature.enabled`와 `StorageServiceFeatureEnabled` 참조가 남지 않는다.
+- `sharedfs.feature.enabled=true`에서 `listSharedFileSystems`와 `listStorageServiceInstances` API가 모두 노출된다.
+- 기존 Ready SharedFS의 VM ID와 볼륨 ID가 있으면 관리 서버 재시작 후 `storage_service_instance`가 생성된다.
+- 기존 폐기 설정 행이 DB에서 제거된다.
+- 로그인 화면과 `/client/` 정적 리소스가 정상 응답하고 SharedFS 상세 탭이 서비스 인스턴스를 조회한다.

--- a/engine/schema/src/main/java/com/cloud/vm/dao/NicDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/NicDaoImpl.java
@@ -186,7 +186,7 @@ public class NicDaoImpl extends GenericDaoBase<NicVO, Long> implements NicDao {
         builder.set(update, "secondaryIp", secondaryIp);
         final SearchCriteria<NicVO> criteria = createSearchCriteria();
         criteria.addAnd("id", Op.EQ, nicId);
-        criteria.addAnd("iPv4Address", expectedPrimaryIp == null ? Op.NULL : Op.EQ, expectedPrimaryIp);
+        addExpectedPrimaryIpCondition(criteria, expectedPrimaryIp);
         return update(update, criteria) == 1;
     }
 
@@ -197,8 +197,16 @@ public class NicDaoImpl extends GenericDaoBase<NicVO, Long> implements NicDao {
         builder.set(update, "iPv4Address", primaryIp);
         final SearchCriteria<NicVO> criteria = createSearchCriteria();
         criteria.addAnd("id", Op.EQ, nicId);
-        criteria.addAnd("iPv4Address", expectedPrimaryIp == null ? Op.NULL : Op.EQ, expectedPrimaryIp);
+        addExpectedPrimaryIpCondition(criteria, expectedPrimaryIp);
         return update(update, criteria) == 1;
+    }
+
+    protected void addExpectedPrimaryIpCondition(final SearchCriteria<NicVO> criteria, final String expectedPrimaryIp) {
+        if (expectedPrimaryIp == null) {
+            criteria.addAnd("iPv4Address", Op.NULL);
+        } else {
+            criteria.addAnd("iPv4Address", Op.EQ, expectedPrimaryIp);
+        }
     }
 
     private NicVO findByNetworkIdAndTypeInternal(long networkId, VirtualMachine.Type vmType, boolean includingRemoved) {

--- a/engine/schema/src/main/resources/META-INF/db/schema-Diplo-After.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-Diplo-After.sql
@@ -201,3 +201,5 @@ CREATE TABLE IF NOT EXISTS `cloud`.`storage_identity_domain` (
   KEY `idx_storage_identity_domain__instance_id` (`instance_id`),
   KEY `idx_storage_identity_domain__domain_name` (`domain_name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+DELETE FROM `cloud`.`configuration` WHERE `name` = 'storage.service.feature.enabled';

--- a/engine/schema/src/test/java/com/cloud/vm/dao/NicDaoImplTest.java
+++ b/engine/schema/src/test/java/com/cloud/vm/dao/NicDaoImplTest.java
@@ -66,4 +66,22 @@ public class NicDaoImplTest {
                 Mockito.any(SearchCriteria.class), Mockito.any(Filter.class), Mockito.eq(null),
                 Mockito.eq(false));
     }
+
+    @Test
+    public void addExpectedPrimaryIpConditionUsesNullOperatorWithoutParameters() {
+        final SearchCriteria<NicVO> criteria = Mockito.mock(SearchCriteria.class);
+
+        nicDaoImplSpy.addExpectedPrimaryIpCondition(criteria, null);
+
+        Mockito.verify(criteria).addAnd("iPv4Address", SearchCriteria.Op.NULL);
+    }
+
+    @Test
+    public void addExpectedPrimaryIpConditionUsesEqualityForPersistedAddress() {
+        final SearchCriteria<NicVO> criteria = Mockito.mock(SearchCriteria.class);
+
+        nicDaoImplSpy.addExpectedPrimaryIpCondition(criteria, "10.10.254.71");
+
+        Mockito.verify(criteria).addAnd("iPv4Address", SearchCriteria.Op.EQ, "10.10.254.71");
+    }
 }

--- a/server/src/main/java/org/apache/cloudstack/storage/dataservice/StorageServiceManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/storage/dataservice/StorageServiceManagerImpl.java
@@ -219,6 +219,9 @@ public class StorageServiceManagerImpl extends ManagerBase implements StorageSer
     @Override
     public List<Class<?>> getCommands() {
         final List<Class<?>> commands = new ArrayList<>();
+        if (!SharedFS.SharedFSFeatureEnabled.value()) {
+            return commands;
+        }
         commands.add(CreateStorageServiceInstanceCmd.class);
         commands.add(ListStorageServiceInstancesCmd.class);
         commands.add(EnableStorageServiceProtocolCmd.class);
@@ -343,7 +346,8 @@ public class StorageServiceManagerImpl extends ManagerBase implements StorageSer
         final String protocolMode = resolveProtocolModeForEnable(protocol, modeProtocol, cmd.getProtocolMode());
         validateProtocolModeEndpointPolicy(protocol, modeProtocol, protocolMode, cmd.getListenIp(), port);
         validateBlockProtocolListenerConflict(instance, protocol, cmd.getListenIp(), port, protocolVO);
-        final NicVO listenNic = resolveProtocolListenAddress(instance, cmd.getListenIp());
+        NicVO listenNic = resolveProtocolListenAddress(instance, cmd.getListenIp());
+        listenNic = reconcileProtocolListenNicIdentity(instance, listenNic);
         final String protocolConfigJson = buildProtocolConfigJson(protocol, null, protocolMode, port, cmd.getListenIp());
         final boolean dualModeServiceIpRegistration = protocol == StorageServiceInstance.Protocol.NFS
                 && modeProtocol != null && "V3V4_DUAL".equals(protocolMode);
@@ -5211,6 +5215,30 @@ public class StorageServiceManagerImpl extends ManagerBase implements StorageSer
         return true;
     }
 
+    protected NicVO reconcileProtocolListenNicIdentity(final StorageServiceInstanceVO instance, final NicVO targetNic) {
+        if (targetNic == null || StringUtils.isNotBlank(targetNic.getIPv4Address())) {
+            return targetNic;
+        }
+        final String runtimePrimaryIp = observeRuntimePrimaryIp(instance);
+        if (StringUtils.isBlank(runtimePrimaryIp)) {
+            throw new CloudRuntimeException("Unable to determine the primary IPv4 address of the Storage Service System VM NIC before registering a listen IP");
+        }
+        if (!nicDao.updatePrimaryIpAddress(targetNic.getId(), runtimePrimaryIp, null)) {
+            final NicVO concurrentNic = nicDao.findById(targetNic.getId());
+            if (concurrentNic != null && StringUtils.equals(runtimePrimaryIp, concurrentNic.getIPv4Address())) {
+                return concurrentNic;
+            }
+            throw new CloudRuntimeException("Storage Service NIC changed while synchronizing its runtime primary IPv4 address");
+        }
+        final NicVO reconciledNic = nicDao.findById(targetNic.getId());
+        if (reconciledNic == null || !StringUtils.equals(runtimePrimaryIp, reconciledNic.getIPv4Address())) {
+            throw new CloudRuntimeException("Storage Service NIC primary IPv4 synchronization did not persist the observed runtime address");
+        }
+        logger.info("Synchronized Storage Service NIC [{}] primary IPv4 address [{}] from the running System VM before registering a listen IP",
+                reconciledNic.getUuid(), runtimePrimaryIp);
+        return reconciledNic;
+    }
+
     protected void ensureGuestProtocolListenAddress(final StorageServiceInstanceVO instance, final String listenIp, final NicVO targetNic, final Integer port) {
         if (targetNic == null || StringUtils.isBlank(listenIp) || "0.0.0.0".equals(listenIp) || "::".equals(listenIp) || instance.getVmId() == null) {
             return;
@@ -6383,7 +6411,6 @@ public class StorageServiceManagerImpl extends ManagerBase implements StorageSer
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {
-                StorageServiceInstance.StorageServiceFeatureEnabled,
                 StorageServiceInstance.StorageServiceCommandTimeout
         };
     }

--- a/server/src/main/java/org/apache/cloudstack/storage/sharedfs/SharedFSServiceImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/storage/sharedfs/SharedFSServiceImpl.java
@@ -192,6 +192,7 @@ public class SharedFSServiceImpl extends ManagerBase implements SharedFSService,
             sharedFSProviderMap.put(provider.getName(), provider);
             provider.configure();
         }
+        reconcileSharedFSToStorageService();
         _executor.scheduleWithFixedDelay(new SharedFSGarbageCollector(), SharedFSCleanupInterval.value(), SharedFSCleanupInterval.value(), TimeUnit.SECONDS);
         return true;
     }
@@ -733,7 +734,7 @@ public class SharedFSServiceImpl extends ManagerBase implements SharedFSService,
     }
 
     protected void syncSharedFSToStorageService(SharedFS sharedFS) {
-        if (sharedFS == null || !StorageServiceInstance.StorageServiceFeatureEnabled.value()) {
+        if (sharedFS == null || !SharedFSFeatureEnabled.value()) {
             return;
         }
         if (sharedFS.getVmId() == null || sharedFS.getVolumeId() == null) {
@@ -786,6 +787,24 @@ public class SharedFSServiceImpl extends ManagerBase implements SharedFSService,
         }
     }
 
+    protected void reconcileSharedFSToStorageService() {
+        if (!SharedFSFeatureEnabled.value()) {
+            return;
+        }
+        for (SharedFSVO sharedFS : sharedFSDao.listAll()) {
+            if (!shouldReconcileSharedFSToStorageService(sharedFS)) {
+                continue;
+            }
+            syncSharedFSToStorageService(sharedFS);
+        }
+    }
+
+    protected boolean shouldReconcileSharedFSToStorageService(SharedFS sharedFS) {
+        return sharedFS != null && sharedFS.getVmId() != null && sharedFS.getVolumeId() != null &&
+                !State.Destroyed.equals(sharedFS.getState()) && !State.Expunging.equals(sharedFS.getState()) &&
+                !State.Expunged.equals(sharedFS.getState());
+    }
+
     protected void removeLegacySharedFSRootExport(StorageServiceInstanceVO instance) {
         for (StorageFileShareVO share : storageFileShareDao.listByInstanceIdAndProtocol(instance.getId(), StorageServiceInstance.Protocol.NFS)) {
             if (SharedFS.SharedFSPath.equals(StringUtils.removeEnd(share.getPath(), "/"))) {
@@ -798,7 +817,7 @@ public class SharedFSServiceImpl extends ManagerBase implements SharedFSService,
     }
 
     protected void deleteStorageServiceCompatibility(SharedFS sharedFS) {
-        if (sharedFS == null || !StorageServiceInstance.StorageServiceFeatureEnabled.value() || sharedFS.getVmId() == null) {
+        if (sharedFS == null || !SharedFSFeatureEnabled.value() || sharedFS.getVmId() == null) {
             return;
         }
         try {

--- a/server/src/main/java/org/apache/cloudstack/storage/sharedfs/SharedFSServiceImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/storage/sharedfs/SharedFSServiceImpl.java
@@ -282,6 +282,15 @@ public class SharedFSServiceImpl extends ManagerBase implements SharedFSService,
         if ((diskOffering.isCustomizedIops() == null || diskOffering.isCustomizedIops() == false) && (minIops != null || maxIops != null)) {
             throw new InvalidParameterValueException("Iops provided with a non-custom-iops disk offering");
         }
+        if ((minIops == null) != (maxIops == null)) {
+            throw new InvalidParameterValueException("Either 'miniops' and 'maxiops' must both be provided or neither must be provided.");
+        }
+        if (minIops != null && (minIops <= 0 || maxIops <= 0)) {
+            throw new InvalidParameterValueException("The 'miniops' and 'maxiops' parameters must be greater than zero.");
+        }
+        if (minIops != null && minIops > maxIops) {
+            throw new InvalidParameterValueException("The 'miniops' parameter must be less than or equal to the 'maxiops' parameter.");
+        }
     }
 
     private void validateInitialBackingStorage(Long diskOfferingId, Long storageId, DataCenter zone) {

--- a/server/src/test/java/org/apache/cloudstack/storage/dataservice/StorageServiceManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/storage/dataservice/StorageServiceManagerImplTest.java
@@ -19,7 +19,14 @@ package org.apache.cloudstack.storage.dataservice;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import org.apache.cloudstack.storage.sharedfs.SharedFS;
+
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.vm.NicVO;
+import com.cloud.vm.dao.NicDao;
 import com.google.gson.JsonObject;
 
 public class StorageServiceManagerImplTest {
@@ -40,5 +47,54 @@ public class StorageServiceManagerImplTest {
         final JsonObject observation = manager.unavailableRuntimeObservation(snapshot);
 
         Assert.assertEquals("UNAVAILABLE", observation.get("mappingStatus").getAsString());
+    }
+
+    @Test
+    public void storageServiceTimeoutUsesSharedFSFeatureGate() {
+        Assert.assertEquals(SharedFS.SharedFSFeatureEnabled.key(), StorageServiceInstance.StorageServiceCommandTimeout.parent());
+    }
+
+    @Test
+    public void reconcileProtocolListenNicIdentityPersistsObservedPrimaryIp() {
+        final StorageServiceManagerImpl managerSpy = Mockito.spy(new StorageServiceManagerImpl());
+        final NicDao nicDao = Mockito.mock(NicDao.class);
+        final StorageServiceInstanceVO instance = Mockito.mock(StorageServiceInstanceVO.class);
+        final NicVO targetNic = Mockito.mock(NicVO.class);
+        final NicVO reconciledNic = Mockito.mock(NicVO.class);
+        ReflectionTestUtils.setField(managerSpy, "nicDao", nicDao);
+        Mockito.when(targetNic.getId()).thenReturn(38L);
+        Mockito.when(targetNic.getIPv4Address()).thenReturn(null);
+        Mockito.when(reconciledNic.getIPv4Address()).thenReturn("10.10.254.71");
+        Mockito.when(nicDao.updatePrimaryIpAddress(38L, "10.10.254.71", null)).thenReturn(true);
+        Mockito.when(nicDao.findById(38L)).thenReturn(reconciledNic);
+        Mockito.doReturn("10.10.254.71").when(managerSpy).observeRuntimePrimaryIp(instance);
+
+        Assert.assertSame(reconciledNic, managerSpy.reconcileProtocolListenNicIdentity(instance, targetNic));
+        Mockito.verify(nicDao).updatePrimaryIpAddress(38L, "10.10.254.71", null);
+    }
+
+    @Test
+    public void reconcileProtocolListenNicIdentityKeepsPersistedPrimaryIp() {
+        final StorageServiceManagerImpl managerSpy = Mockito.spy(new StorageServiceManagerImpl());
+        final NicDao nicDao = Mockito.mock(NicDao.class);
+        final StorageServiceInstanceVO instance = Mockito.mock(StorageServiceInstanceVO.class);
+        final NicVO targetNic = Mockito.mock(NicVO.class);
+        ReflectionTestUtils.setField(managerSpy, "nicDao", nicDao);
+        Mockito.when(targetNic.getIPv4Address()).thenReturn("10.10.254.71");
+
+        Assert.assertSame(targetNic, managerSpy.reconcileProtocolListenNicIdentity(instance, targetNic));
+        Mockito.verifyNoInteractions(nicDao);
+        Mockito.verify(managerSpy, Mockito.never()).observeRuntimePrimaryIp(Mockito.any());
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void reconcileProtocolListenNicIdentityRejectsUnavailableRuntimePrimaryIp() {
+        final StorageServiceManagerImpl managerSpy = Mockito.spy(new StorageServiceManagerImpl());
+        final StorageServiceInstanceVO instance = Mockito.mock(StorageServiceInstanceVO.class);
+        final NicVO targetNic = Mockito.mock(NicVO.class);
+        Mockito.when(targetNic.getIPv4Address()).thenReturn(null);
+        Mockito.doReturn(null).when(managerSpy).observeRuntimePrimaryIp(instance);
+
+        managerSpy.reconcileProtocolListenNicIdentity(instance, targetNic);
     }
 }

--- a/server/src/test/java/org/apache/cloudstack/storage/sharedfs/SharedFSServiceImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/storage/sharedfs/SharedFSServiceImplTest.java
@@ -348,6 +348,26 @@ public class SharedFSServiceImplTest {
     }
 
     @Test
+    public void testSharedFSStorageServiceReconciliationEligibility() {
+        SharedFSVO ready = mock(SharedFSVO.class);
+        when(ready.getVmId()).thenReturn(s_vmId);
+        when(ready.getVolumeId()).thenReturn(s_volumeId);
+        when(ready.getState()).thenReturn(SharedFS.State.Ready);
+        Assert.assertTrue(sharedFSServiceImpl.shouldReconcileSharedFSToStorageService(ready));
+
+        SharedFSVO destroyed = mock(SharedFSVO.class);
+        when(destroyed.getVmId()).thenReturn(s_vmId);
+        when(destroyed.getVolumeId()).thenReturn(s_volumeId);
+        when(destroyed.getState()).thenReturn(SharedFS.State.Destroyed);
+        Assert.assertFalse(sharedFSServiceImpl.shouldReconcileSharedFSToStorageService(destroyed));
+
+        SharedFSVO unbound = mock(SharedFSVO.class);
+        when(unbound.getVmId()).thenReturn(s_vmId);
+        when(unbound.getVolumeId()).thenReturn(null);
+        Assert.assertFalse(sharedFSServiceImpl.shouldReconcileSharedFSToStorageService(unbound));
+    }
+
+    @Test
     public void testAllocSharedFSInvalidFsFormat() {
         CreateSharedFSCmd cmd = getMockCreateSharedFSCmd();
 

--- a/server/src/test/java/org/apache/cloudstack/storage/sharedfs/SharedFSServiceImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/storage/sharedfs/SharedFSServiceImplTest.java
@@ -318,6 +318,36 @@ public class SharedFSServiceImplTest {
     }
 
     @Test
+    public void testAllocSharedFSInvalidCustomizedIops() {
+        CreateSharedFSCmd cmd = getMockCreateSharedFSCmd();
+
+        DataCenterVO zone = mock(DataCenterVO.class);
+        when(dataCenterDao.findById(s_zoneId)).thenReturn(zone);
+        when(zone.getAllocationState()).thenReturn(Grouping.AllocationState.Enabled);
+
+        DiskOfferingVO diskOfferingVO = mock(DiskOfferingVO.class);
+        when(diskOfferingDao.findById(s_diskOfferingId)).thenReturn(diskOfferingVO);
+        when(diskOfferingVO.isCustomized()).thenReturn(true);
+        when(diskOfferingVO.isCustomizedIops()).thenReturn(true);
+
+        when(cmd.getMinIops()).thenReturn(s_minIops);
+        when(cmd.getMaxIops()).thenReturn(null);
+        Assert.assertThrows(InvalidParameterValueException.class, () -> sharedFSServiceImpl.allocSharedFS(cmd));
+
+        when(cmd.getMinIops()).thenReturn(null);
+        when(cmd.getMaxIops()).thenReturn(s_maxIops);
+        Assert.assertThrows(InvalidParameterValueException.class, () -> sharedFSServiceImpl.allocSharedFS(cmd));
+
+        when(cmd.getMinIops()).thenReturn(0L);
+        when(cmd.getMaxIops()).thenReturn(s_maxIops);
+        Assert.assertThrows(InvalidParameterValueException.class, () -> sharedFSServiceImpl.allocSharedFS(cmd));
+
+        when(cmd.getMinIops()).thenReturn(s_maxIops);
+        when(cmd.getMaxIops()).thenReturn(s_minIops);
+        Assert.assertThrows(InvalidParameterValueException.class, () -> sharedFSServiceImpl.allocSharedFS(cmd));
+    }
+
+    @Test
     public void testAllocSharedFSInvalidFsFormat() {
         CreateSharedFSCmd cmd = getMockCreateSharedFSCmd();
 

--- a/tools/build/rocky97-rpm-build.sh
+++ b/tools/build/rocky97-rpm-build.sh
@@ -217,7 +217,21 @@ if [ "$LOCAL_FAST" == "true" ]; then
 fi
 
 cd "$ROOT_DIR/packaging"
-./package.sh "${build_args[@]}"
+package_status=0
+./package.sh "${build_args[@]}" || package_status=$?
+
+if [ "$package_status" -ne 0 ]; then
+    echo "RPM packaging failed once; cleaning incomplete Maven downloads and retrying"
+    find /root/.m2/repository -type f -name '*.part' -delete 2>/dev/null || true
+    sleep 5
+    package_status=0
+    ./package.sh "${build_args[@]}" || package_status=$?
+fi
+
+if [ "$package_status" -ne 0 ]; then
+    echo "RPM packaging failed after retry" >&2
+    exit "$package_status"
+fi
 
 cd "$ROOT_DIR"
 find dist/rpmbuild -type f \( -name '*.rpm' -o -name '*.src.rpm' \) | sort \

--- a/ui/src/api/index.js
+++ b/ui/src/api/index.js
@@ -23,6 +23,15 @@ import {
   ACCESS_TOKEN
 } from '@/store/mutation-types'
 
+export function appendApiData (params, data = {}) {
+  Object.entries(data).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      params.append(key, value)
+    }
+  })
+  return params
+}
+
 export function api (command, args = {}, method = 'GET', data = {}) {
   let params = {}
   args.command = command
@@ -30,9 +39,7 @@ export function api (command, args = {}, method = 'GET', data = {}) {
 
   if (data) {
     params = new URLSearchParams()
-    Object.entries(data).forEach(([key, value]) => {
-      params.append(key, value)
-    })
+    appendApiData(params, data)
   }
 
   const sessionkey = vueProps.$localStorage.get(ACCESS_TOKEN) || Cookies.get('sessionkey')

--- a/ui/src/views/storage/CreateSharedFS.vue
+++ b/ui/src/views/storage/CreateSharedFS.vue
@@ -1279,6 +1279,8 @@ export default {
         useexistingvolume: false,
         storageid: '',
         existingvolumeid: '',
+        miniops: null,
+        maxiops: null,
         importmode: 'INSPECT_ONLY',
         resizeallowed: true
       })
@@ -1375,22 +1377,8 @@ export default {
             return Promise.resolve()
           }
         }],
-        miniops: [{
-          validator: async (rule, value) => {
-            if (value && (isNaN(value) || value <= 0)) {
-              return Promise.reject(this.$t('message.error.number'))
-            }
-            return Promise.resolve()
-          }
-        }],
-        maxiops: [{
-          validator: async (rule, value) => {
-            if (value && (isNaN(value) || value <= 0)) {
-              return Promise.reject(this.$t('message.error.number'))
-            }
-            return Promise.resolve()
-          }
-        }]
+        miniops: [{ validator: this.validateCustomizedIops }],
+        maxiops: [{ validator: this.validateCustomizedIops }]
       })
     },
     filterOption (input, option) {
@@ -1719,7 +1707,59 @@ export default {
       const diskoffering = this.diskofferings.filter(x => x.id === id)
       this.customDiskOffering = diskoffering[0]?.iscustomized || false
       this.isCustomizedDiskIOps = diskoffering[0]?.iscustomizediops || false
+      if (!this.isCustomizedDiskIOps) {
+        this.form.miniops = null
+        this.form.maxiops = null
+      }
       this.reconcileSelectedStoragePool()
+    },
+    hasFormValue (value) {
+      return value !== undefined && value !== null && value !== ''
+    },
+    validateCustomizedIops () {
+      if (!this.isCustomizedDiskIOps) {
+        return Promise.resolve()
+      }
+      const hasMin = this.hasFormValue(this.form.miniops)
+      const hasMax = this.hasFormValue(this.form.maxiops)
+      if (hasMin !== hasMax) {
+        return Promise.reject(this.$t('label.required'))
+      }
+      if (!hasMin) {
+        return Promise.resolve()
+      }
+      const minIops = Number(this.form.miniops)
+      const maxIops = Number(this.form.maxiops)
+      if (!Number.isInteger(minIops) || !Number.isInteger(maxIops) || minIops <= 0 || maxIops <= 0 || minIops > maxIops) {
+        return Promise.reject(this.$t('message.error.number'))
+      }
+      return Promise.resolve()
+    },
+    buildCreateSharedFsRequest (values) {
+      const data = {
+        name: values.name,
+        description: values.description,
+        zoneid: values.zoneid,
+        serviceofferingid: values.serviceofferingid,
+        diskofferingid: values.diskofferingid,
+        networkid: values.networkid,
+        size: this.createSharedFsSize(values),
+        filesystem: values.filesystem,
+        domainid: this.owner.domainid
+      }
+      if (this.isCustomizedDiskIOps && this.hasFormValue(values.miniops) && this.hasFormValue(values.maxiops)) {
+        data.miniops = Number(values.miniops)
+        data.maxiops = Number(values.maxiops)
+      }
+      if (this.owner.projectid) {
+        data.projectid = this.owner.projectid
+      } else {
+        data.account = this.owner.account
+      }
+      if (values.storageid) {
+        data.storageid = values.storageid
+      }
+      return this.cleanParams(data)
     },
     handleSubmit (e) {
       if (e && e.preventDefault) {
@@ -1731,27 +1771,7 @@ export default {
         const formRaw = toRaw(this.form)
         const values = this.handleRemoveFields(formRaw)
 
-        var data = {
-          name: values.name,
-          description: values.description,
-          zoneid: values.zoneid,
-          serviceofferingid: values.serviceofferingid,
-          diskofferingid: values.diskofferingid,
-          networkid: values.networkid,
-          size: this.createSharedFsSize(values),
-          filesystem: values.filesystem,
-          miniops: values.miniops,
-          maxiops: values.maxiops,
-          domainid: this.owner.domainid
-        }
-        if (this.owner.projectid) {
-          data.projectid = this.owner.projectid
-        } else {
-          data.account = this.owner.account
-        }
-        if (values.storageid) {
-          data.storageid = values.storageid
-        }
+        const data = this.buildCreateSharedFsRequest(values)
         const missingApis = this.missingStorageServiceSetupApis()
         if (missingApis.length > 0) {
           this.$notification.error({

--- a/ui/tests/unit/api/index.spec.js
+++ b/ui/tests/unit/api/index.spec.js
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { appendApiData } from '@/api'
+
+describe('API form data serialization', () => {
+  it('omits absent values instead of serializing them as strings', () => {
+    const params = appendApiData(new URLSearchParams(), {
+      miniops: undefined,
+      maxiops: null,
+      size: 0,
+      enabled: false,
+      description: ''
+    })
+
+    expect(params.has('miniops')).toBe(false)
+    expect(params.has('maxiops')).toBe(false)
+    expect(params.get('size')).toBe('0')
+    expect(params.get('enabled')).toBe('false')
+    expect(params.get('description')).toBe('')
+  })
+})

--- a/ui/tests/unit/views/storage/CreateSharedFS.spec.js
+++ b/ui/tests/unit/views/storage/CreateSharedFS.spec.js
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import CreateSharedFS from '@/views/storage/CreateSharedFS'
+
+const baseContext = customizedIops => ({
+  isCustomizedDiskIOps: customizedIops,
+  owner: { domainid: 'domain-1', account: 'admin' },
+  createSharedFsSize: () => undefined,
+  hasFormValue: CreateSharedFS.methods.hasFormValue,
+  cleanParams: CreateSharedFS.methods.cleanParams
+})
+
+const values = {
+  name: 'sharedfs-test',
+  description: '',
+  zoneid: 'zone-1',
+  serviceofferingid: 'service-offering-1',
+  diskofferingid: 'disk-offering-1',
+  networkid: 'network-1',
+  filesystem: 'XFS',
+  storageid: 'storage-1'
+}
+
+describe('CreateSharedFS request normalization', () => {
+  it('omits IOPS for a non-customized IOPS offering', () => {
+    const context = baseContext(false)
+    const request = CreateSharedFS.methods.buildCreateSharedFsRequest.call(context, {
+      ...values,
+      miniops: undefined,
+      maxiops: undefined
+    })
+
+    expect(request.miniops).toBeUndefined()
+    expect(request.maxiops).toBeUndefined()
+    expect(request.storageid).toBe('storage-1')
+  })
+
+  it('includes a complete customized IOPS pair as numbers', () => {
+    const context = baseContext(true)
+    const request = CreateSharedFS.methods.buildCreateSharedFsRequest.call(context, {
+      ...values,
+      miniops: '1000',
+      maxiops: '2000'
+    })
+
+    expect(request.miniops).toBe(1000)
+    expect(request.maxiops).toBe(2000)
+  })
+})


### PR DESCRIPTION
## 개요

Diplo 환경에서 공유 파일시스템 생성 요청이 잘못 직렬화되거나, 기능 플래그와 Storage Service 모델이 불일치하고, 런타임 NIC 정보가 DB와 어긋나 후속 프로토콜 활성화가 실패하는 문제를 안정화합니다.

## 주요 변경 사항

### 공유 파일시스템 생성 요청 안정화

- API POST 파라미터에서 `undefined`와 `null` 값을 전송하지 않도록 공통 직렬화 경로를 보강했습니다.
- 사용자 지정 IOPS 디스크 오퍼링에서만 `miniops`와 `maxiops`를 함께 전송하도록 생성 화면을 정리했습니다.
- 서버에서도 두 IOPS 값의 동시 입력, 양의 정수 여부, 최소값과 최대값의 순서를 검증합니다.
- 생성 화면과 공통 API 직렬화 동작을 단위 테스트로 고정했습니다.

### SharedFS와 Storage Service 모델 정합성

- `sharedfs.feature.enabled`를 SharedFS 및 Storage Service의 단일 기능 플래그로 사용하도록 통합했습니다.
- 관리 서버 시작 시 기존 Ready SharedFS에 대응하는 `storage_service_instance`와 기본 NFS 프로토콜 모델이 누락된 경우 멱등하게 복구합니다.
- 더 이상 사용하지 않는 별도 Storage Service 기능 설정을 Diplo 후처리 스키마에서 정리합니다.
- 기존 SharedFS 수명주기와 모델 복구 동작을 테스트로 검증했습니다.

### 프로토콜 활성화 런타임 정합성

- Storage Service VM의 실제 기본 IP와 DB NIC 기본 IP가 다를 때 NIC 식별 정보를 조건부로 동기화합니다.
- 프로토콜 활성화 전에 수신 NIC를 다시 조정해 보조 IP 등록과 런타임 설정이 일치하도록 했습니다.
- 동시 변경을 덮어쓰지 않도록 기대 기본 IP 조건을 사용하는 DAO 갱신과 테스트를 추가했습니다.

### 테스트 릴리즈 빌드 안정화

- Rocky 9.7 RPM 빌드에서 Maven 임시 다운로드 파일 문제로 패키징이 실패하면 불완전한 `.part` 파일만 정리하고 한 번 재시도합니다.
- 두 번째 패키징도 실패하면 기존처럼 빌드를 실패 처리하므로 실제 컴파일 및 패키징 오류는 숨기지 않습니다.

## 검증 결과

- `NicDaoImplTest`: 4개 테스트 통과
- `StorageServiceManagerImplTest`, `SharedFSServiceImplTest`: 38개 테스트 통과
- `mvn -pl server -am -DskipTests package`: 성공
- [ABLESTACK Branch Development Release #31091241006](https://github.com/dhslove/ablestack-cloud/actions/runs/31091241006): 성공
  - `noredist` Rocky 9.7 RPM 9개 생성
  - KVM SystemVM 템플릿 생성
  - `SHA256SUMS`, `SYSTEMVM-SHA256SUMS` 생성
  - Draft 테스트 릴리즈 자산 17개 업로드

## 영향 범위

- Diplo SharedFS 생성 UI 및 API 요청
- SharedFS와 Storage Service 관리 서버 모델
- Storage Service 프로토콜 수신 NIC 정합성
- Diplo DB 후처리 스키마
- Rocky 9.7 noredist 테스트 릴리즈 빌드

기존 로컬 `ui/public/config.json` 변경은 본 PR 범위와 무관하여 포함하지 않았습니다.
