### PR TITLE
RPM 설치 정합성 및 릴리스 제품 버전 메타데이터 통합

### DIFF
--- a/.github/workflows/branch-dev-release.yml
+++ b/.github/workflows/branch-dev-release.yml
@@ -38,6 +38,26 @@ on:
         required: false
         default: ''
         type: string
+      release_stage:
+        description: Product release stage embedded in the test packages
+        required: true
+        default: alpha
+        type: choice
+        options:
+          - alpha
+          - beta
+          - rc
+          - ga
+      prerelease_number:
+        description: Positive sequence for alpha, beta, or rc; leave empty for ga
+        required: false
+        default: '1'
+        type: string
+      build_date:
+        description: Optional fixed UTC build date in YYYYMMDD format
+        required: false
+        default: ''
+        type: string
       release_seq:
         description: RPM release sequence appended after the timestamp
         required: true
@@ -87,6 +107,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       brand: ${{ steps.derive.outputs.brand }}
+      display_version: ${{ steps.product.outputs.display_version }}
       package_version: ${{ steps.derive.outputs.package_version }}
       timestamp_value: ${{ steps.derive.outputs.timestamp_value }}
       source_commit_sha: ${{ steps.derive.outputs.source_commit_sha }}
@@ -94,6 +115,7 @@ jobs:
       release_name: ${{ steps.derive.outputs.release_name }}
       rpm_artifact_name: ${{ steps.derive.outputs.rpm_artifact_name }}
       systemvm_artifact_name: ${{ steps.derive.outputs.systemvm_artifact_name }}
+      metadata_artifact_name: ${{ steps.derive.outputs.metadata_artifact_name }}
       ref_slug: ${{ steps.derive.outputs.ref_slug }}
     steps:
       - uses: actions/checkout@v6
@@ -101,17 +123,21 @@ jobs:
           ref: ${{ inputs.source_ref }}
           fetch-depth: 0
 
+      - id: product
+        name: Generate product release metadata
+        run: |
+          python3 tools/build/release_metadata.py \
+            --base-branch "${{ inputs.base_branch }}" \
+            --stage "${{ inputs.release_stage }}" \
+            --number "${{ inputs.prerelease_number }}" \
+            --build-date "${{ inputs.build_date }}" \
+            --git-commit "$(git rev-parse HEAD)" \
+            --workflow-run-id "${{ github.run_id }}" \
+            --output dist/release/release-metadata.json \
+            --github-output "$GITHUB_OUTPUT"
+
       - id: derive
         run: |
-          case "${{ inputs.base_branch }}" in
-            ablestack-europa) brand="Mold.Europa" ;;
-            ablestack-diplo) brand="Mold.Diplo" ;;
-            *)
-              echo "::error::Unsupported base branch ${{ inputs.base_branch }}"
-              exit 1
-              ;;
-          esac
-
           pom_version=$(awk '
             /<artifactId>cloudstack<\/artifactId>/ { seen=1; next }
             seen && /<version>/ {
@@ -144,10 +170,10 @@ jobs:
           timestamp_value=$(date -u +%Y%m%d%H%M)
           source_commit_sha=$(git rev-parse HEAD)
           release_tag="dev-branch-${ref_slug}-latest"
-          release_name="ABLESTACK Branch Dev ${ref_slug} Latest"
+          release_name="ABLESTACK Branch Dev ${ref_slug} - ${{ steps.product.outputs.display_version }}"
 
           {
-            echo "brand=$brand"
+            echo "brand=${{ steps.product.outputs.brand }}"
             echo "package_version=$package_version"
             echo "timestamp_value=$timestamp_value"
             echo "source_commit_sha=$source_commit_sha"
@@ -155,8 +181,16 @@ jobs:
             echo "release_name=$release_name"
             echo "rpm_artifact_name=branch-dev-rocky97-rpm-${{ github.run_id }}"
             echo "systemvm_artifact_name=branch-dev-systemvm-kvm-${{ github.run_id }}"
+            echo "metadata_artifact_name=branch-dev-release-metadata-${{ github.run_id }}"
             echo "ref_slug=$ref_slug"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Upload release metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.derive.outputs.metadata_artifact_name }}
+          if-no-files-found: error
+          path: dist/release/release-metadata.json
 
   build-rpm:
     needs: metadata
@@ -168,6 +202,7 @@ jobs:
       release: ${{ inputs.release_seq }}
       brand: ${{ needs.metadata.outputs.brand }}
       package_version: ${{ needs.metadata.outputs.package_version }}
+      ui_build_version: ${{ needs.metadata.outputs.display_version }}
       use_timestamp: true
       timestamp_value: ${{ needs.metadata.outputs.timestamp_value }}
       build_srpm: ${{ inputs.build_srpm }}
@@ -183,6 +218,7 @@ jobs:
       version: ${{ needs.metadata.outputs.package_version }}
       build_number: ${{ github.run_number }}
       artifact_name: ${{ needs.metadata.outputs.systemvm_artifact_name }}
+      release_display_version: ${{ needs.metadata.outputs.display_version }}
 
   publish-release:
     needs:
@@ -233,6 +269,12 @@ jobs:
           name: ${{ needs.metadata.outputs.rpm_artifact_name }}
           path: download/rpm
 
+      - name: Download release metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.metadata.outputs.metadata_artifact_name }}
+          path: download/metadata
+
       - name: Download KVM System VM artifacts
         uses: actions/download-artifact@v4
         with:
@@ -243,6 +285,7 @@ jobs:
         run: |
           mkdir -p release-assets
           find download/rpm -type f -exec cp {} release-assets/ \;
+          find download/metadata -type f -exec cp {} release-assets/ \;
           find download/systemvm -type f \
             \( -name '*.qcow2.bz2' -o -name 'SYSTEMVM-*' \) \
             -exec cp {} release-assets/ \;
@@ -253,6 +296,7 @@ jobs:
           Base branch metadata: ${{ inputs.base_branch }}
           Source commit: ${{ needs.metadata.outputs.source_commit_sha }}
           Package version: ${{ needs.metadata.outputs.package_version }}
+          ABLESTACK display version: ${{ needs.metadata.outputs.display_version }}
           Package mode: ${{ inputs.pack }}
           System VM: KVM x86_64 qcow2.bz2
           Timestamp: ${{ needs.metadata.outputs.timestamp_value }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,6 @@ name: ABLESTACK Release
 on:
   workflow_dispatch:
     inputs:
-      release_id:
-        description: Release identifier used for the source release, tag, and GitHub Release
-        required: true
-        type: string
       base_branch:
         description: Branch to release from
         required: true
@@ -32,6 +28,26 @@ on:
         options:
           - ablestack-europa
           - ablestack-diplo
+      release_stage:
+        description: Product release stage
+        required: true
+        default: rc
+        type: choice
+        options:
+          - alpha
+          - beta
+          - rc
+          - ga
+      prerelease_number:
+        description: Positive sequence for alpha, beta, or rc; leave empty for ga
+        required: false
+        default: '1'
+        type: string
+      build_date:
+        description: Optional fixed UTC build date in YYYYMMDD format
+        required: false
+        default: ''
+        type: string
       release_seq:
         description: RPM release sequence appended after the timestamp
         required: true
@@ -78,14 +94,8 @@ on:
         required: false
         default: true
         type: boolean
-      prerelease:
-        description: Mark the GitHub Release as a prerelease
-        required: false
-        default: false
-        type: boolean
-
 concurrency:
-  group: release-${{ inputs.release_id }}
+  group: release-${{ inputs.base_branch }}-${{ inputs.release_stage }}-${{ inputs.prerelease_number }}
   cancel-in-progress: false
 
 permissions:
@@ -96,8 +106,13 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       brand: ${{ steps.derive.outputs.brand }}
+      display_version: ${{ steps.product.outputs.display_version }}
+      release_id: ${{ steps.product.outputs.release_tag }}
+      release_name: ${{ steps.product.outputs.release_name }}
+      is_prerelease: ${{ steps.product.outputs.is_prerelease }}
       package_version: ${{ steps.derive.outputs.package_version }}
       timestamp_value: ${{ steps.derive.outputs.timestamp_value }}
+      metadata_artifact_name: ${{ steps.derive.outputs.metadata_artifact_name }}
       source_artifact_name: ${{ steps.derive.outputs.source_artifact_name }}
       rpm_artifact_name: ${{ steps.derive.outputs.rpm_artifact_name }}
       systemvm_artifact_name: ${{ steps.derive.outputs.systemvm_artifact_name }}
@@ -107,17 +122,21 @@ jobs:
           ref: ${{ inputs.base_branch }}
           fetch-depth: 0
 
+      - id: product
+        name: Generate product release metadata
+        run: |
+          python3 tools/build/release_metadata.py \
+            --base-branch "${{ inputs.base_branch }}" \
+            --stage "${{ inputs.release_stage }}" \
+            --number "${{ inputs.prerelease_number }}" \
+            --build-date "${{ inputs.build_date }}" \
+            --git-commit "$(git rev-parse HEAD)" \
+            --workflow-run-id "${{ github.run_id }}" \
+            --output dist/release/release-metadata.json \
+            --github-output "$GITHUB_OUTPUT"
+
       - id: derive
         run: |
-          case "${{ inputs.base_branch }}" in
-            ablestack-europa) brand="Mold.Europa" ;;
-            ablestack-diplo) brand="Mold.Diplo" ;;
-            *)
-              echo "::error::Unsupported base branch ${{ inputs.base_branch }}"
-              exit 1
-              ;;
-          esac
-
           pom_version=$(awk '
             /<artifactId>cloudstack<\/artifactId>/ { seen=1; next }
             seen && /<version>/ {
@@ -138,13 +157,21 @@ jobs:
           timestamp_value=$(date -u +%Y%m%d%H%M)
 
           {
-            echo "brand=$brand"
+            echo "brand=${{ steps.product.outputs.brand }}"
             echo "package_version=$package_version"
             echo "timestamp_value=$timestamp_value"
-            echo "source_artifact_name=source-release-${{ inputs.release_id }}"
-            echo "rpm_artifact_name=rocky97-rpm-${{ inputs.release_id }}"
-            echo "systemvm_artifact_name=systemvm-kvm-${{ inputs.release_id }}"
+            echo "metadata_artifact_name=release-metadata-${{ github.run_id }}"
+            echo "source_artifact_name=source-release-${{ steps.product.outputs.artifact_version }}"
+            echo "rpm_artifact_name=rocky97-rpm-${{ steps.product.outputs.artifact_version }}"
+            echo "systemvm_artifact_name=systemvm-kvm-${{ steps.product.outputs.artifact_version }}"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Upload release metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.derive.outputs.metadata_artifact_name }}
+          if-no-files-found: error
+          path: dist/release/release-metadata.json
 
   prepare-source-release:
     needs: metadata
@@ -203,7 +230,7 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.RELEASE_GPG_PASSPHRASE }}
         run: |
           args=(
-            --release-id "${{ inputs.release_id }}"
+            --release-id "${{ needs.metadata.outputs.release_id }}"
             --branch "${{ inputs.base_branch }}"
             --outputdir "$GITHUB_WORKSPACE/dist/release/source"
             --timestamp "${{ needs.metadata.outputs.timestamp_value }}"
@@ -229,7 +256,7 @@ jobs:
         if: ${{ inputs.push_refs }}
         run: |
           git push origin "${{ steps.prepare.outputs.rc_branch }}"
-          git push origin "refs/tags/${{ inputs.release_id }}"
+          git push origin "refs/tags/${{ needs.metadata.outputs.release_id }}"
 
       - name: Upload source release artifacts
         uses: actions/upload-artifact@v4
@@ -264,6 +291,7 @@ jobs:
       release: ${{ inputs.release_seq }}
       brand: ${{ needs.metadata.outputs.brand }}
       package_version: ${{ needs.metadata.outputs.package_version }}
+      ui_build_version: ${{ needs.metadata.outputs.display_version }}
       use_timestamp: true
       timestamp_value: ${{ needs.metadata.outputs.timestamp_value }}
       build_srpm: true
@@ -282,6 +310,7 @@ jobs:
       version: ${{ needs.metadata.outputs.package_version }}
       build_number: ${{ github.run_number }}
       artifact_name: ${{ needs.metadata.outputs.systemvm_artifact_name }}
+      release_display_version: ${{ needs.metadata.outputs.display_version }}
 
   publish-release:
     needs:
@@ -296,6 +325,12 @@ jobs:
         with:
           name: ${{ needs.metadata.outputs.source_artifact_name }}
           path: download/source
+
+      - name: Download release metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.metadata.outputs.metadata_artifact_name }}
+          path: download/metadata
 
       - name: Download RPM artifacts
         uses: actions/download-artifact@v4
@@ -313,6 +348,7 @@ jobs:
         run: |
           mkdir -p release-assets
           find download/source -type f -exec cp {} release-assets/ \;
+          find download/metadata -type f -exec cp {} release-assets/ \;
           find download/rpm -type f -exec cp {} release-assets/ \;
           find download/systemvm -type f \
             \( -name '*.qcow2.bz2' -o -name 'SYSTEMVM-*' \) \
@@ -333,7 +369,7 @@ jobs:
           {
             echo "## ABLESTACK Release"
             echo
-            echo "- Release: \`${{ inputs.release_id }}\`"
+            echo "- Release: \`${{ needs.metadata.outputs.release_name }}\`"
             echo "- Source commit: \`${{ needs.prepare-source-release.outputs.source_commit_sha }}\`"
             echo "- Package mode: \`${{ inputs.pack }}\`"
             echo "- System VM hypervisor: \`KVM\`"
@@ -345,10 +381,10 @@ jobs:
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.release_id }}
+          tag_name: ${{ needs.metadata.outputs.release_id }}
           target_commitish: ${{ needs.prepare-source-release.outputs.source_commit_sha }}
-          name: ${{ inputs.release_id }}
+          name: ${{ needs.metadata.outputs.release_name }}
           draft: ${{ inputs.draft }}
-          prerelease: ${{ inputs.prerelease }}
+          prerelease: ${{ needs.metadata.outputs.is_prerelease }}
           generate_release_notes: false
           files: release-assets/*

--- a/.github/workflows/rocky97-rpm.yml
+++ b/.github/workflows/rocky97-rpm.yml
@@ -65,6 +65,11 @@ on:
         required: false
         default: ''
         type: string
+      ui_build_version:
+        description: Optional ABLESTACK display version embedded in the UI config
+        required: false
+        default: ''
+        type: string
       use_timestamp:
         description: Use a timestamped release suffix
         required: false
@@ -112,6 +117,10 @@ on:
         default: ''
         type: string
       package_version:
+        required: false
+        default: ''
+        type: string
+      ui_build_version:
         required: false
         default: ''
         type: string
@@ -170,6 +179,7 @@ jobs:
       BUILD_RELEASE: ${{ inputs.release || github.event.inputs.release || '' }}
       BUILD_BRAND: ${{ inputs.brand || github.event.inputs.brand || '' }}
       BUILD_PACKAGE_VERSION: ${{ inputs.package_version || github.event.inputs.package_version || '' }}
+      BUILD_UI_VERSION: ${{ inputs.ui_build_version || github.event.inputs.ui_build_version || '' }}
       BUILD_USE_TIMESTAMP: ${{ inputs.use_timestamp || github.event.inputs.use_timestamp || 'false' }}
       BUILD_TIMESTAMP_VALUE: ${{ inputs.timestamp_value || github.event.inputs.timestamp_value || '' }}
       BUILD_SRPM: ${{ inputs.build_srpm || github.event.inputs.build_srpm || 'false' }}
@@ -213,6 +223,7 @@ jobs:
             -e RELEASE="$BUILD_RELEASE" \
             -e BRAND="$BUILD_BRAND" \
             -e PACKAGE_VERSION="$BUILD_PACKAGE_VERSION" \
+            -e ABLESTACK_UI_BUILD_VERSION="$BUILD_UI_VERSION" \
             -e USE_TIMESTAMP="$BUILD_USE_TIMESTAMP" \
             -e TIMESTAMP_VALUE="$BUILD_TIMESTAMP_VALUE" \
             -e BUILD_SRPM="$BUILD_SRPM" \

--- a/.github/workflows/systemvm-kvm.yml
+++ b/.github/workflows/systemvm-kvm.yml
@@ -36,6 +36,11 @@ on:
         description: GitHub Actions artifact name
         required: true
         type: string
+      release_display_version:
+        description: ABLESTACK display version recorded in the build manifest
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -53,6 +58,7 @@ jobs:
       SYSTEMVM_VERSION: ${{ inputs.version }}
       SYSTEMVM_BUILD_NUMBER: ${{ inputs.build_number }}
       SYSTEMVM_ARTIFACT_NAME: ${{ inputs.artifact_name }}
+      SYSTEMVM_RELEASE_DISPLAY_VERSION: ${{ inputs.release_display_version }}
       SYSTEMVM_ISO_CACHE: ${{ github.workspace }}/.cache/systemvm
 
     steps:
@@ -208,6 +214,7 @@ jobs:
           cat > "$stage_dir/SYSTEMVM-BUILD-MANIFEST.txt" <<EOF
           Source commit: $(git rev-parse HEAD)
           Version: $SYSTEMVM_VERSION
+          ABLESTACK display version: ${SYSTEMVM_RELEASE_DISPLAY_VERSION:-not-specified}
           Build number: $SYSTEMVM_BUILD_NUMBER
           Architecture: x86_64
           Hypervisor: KVM
@@ -226,6 +233,7 @@ jobs:
             echo "- Ref: \`$SYSTEMVM_REF\`"
             echo "- Source commit: \`$(git rev-parse HEAD)\`"
             echo "- Version: \`$SYSTEMVM_VERSION\`"
+            echo "- ABLESTACK display version: \`${SYSTEMVM_RELEASE_DISPLAY_VERSION:-not-specified}\`"
             echo "- Build number: \`$SYSTEMVM_BUILD_NUMBER\`"
             echo "- Hypervisor: \`KVM\`"
             echo "- Architecture: \`x86_64\`"

--- a/packaging/centos8/cloud.spec
+++ b/packaging/centos8/cloud.spec
@@ -313,6 +313,7 @@ install -D packaging/centos8/cloud.limits ${RPM_BUILD_ROOT}%{_sysconfdir}/securi
 install -D packaging/centos8/filelimit.conf ${RPM_BUILD_ROOT}%{_sysconfdir}/systemd/system/%{name}-management.service.d
 install -D packaging/systemd/cloudstack-management.service ${RPM_BUILD_ROOT}%{_unitdir}/mold.service
 install -D packaging/systemd/cloudstack-management.default ${RPM_BUILD_ROOT}%{_sysconfdir}/default/%{name}-management
+install -D packaging/systemd/cloudstack-management-cleanup-jars ${RPM_BUILD_ROOT}%{_bindir}/cloudstack-management-cleanup-jars
 install -D server/target/conf/cloudstack-sudoers ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d/%{name}-management
 touch ${RPM_BUILD_ROOT}%{_localstatedir}/run/%{name}-management.pid
 #install -D server/target/conf/cloudstack-catalina.logrotate ${RPM_BUILD_ROOT}%{_sysconfdir}/logrotate.d/%{name}-catalina
@@ -507,6 +508,10 @@ if [ -f "/usr/share/cloudstack-common/scripts/installer/cloudstack-help-text" ];
 fi
 /usr/bin/systemctl daemon-reload
 /usr/bin/systemctl enable mold > /dev/null 2>&1 || true
+if ! %{_bindir}/cloudstack-management-cleanup-jars; then
+    echo "Failed to quarantine unmanaged CloudStack jars; refusing to start mold" >&2
+    exit 1
+fi
 if /usr/bin/systemctl is-active --quiet mold; then
     /usr/bin/systemctl restart mold || true
 else
@@ -660,6 +665,7 @@ pip3 install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz
 %attr(0755,root,root) %{_bindir}/%{name}-setup-encryption
 %attr(0755,root,root) %{_bindir}/mold
 %attr(0755,root,root) %{_bindir}/mold-update-dbpassword
+%attr(0755,root,root) %{_bindir}/cloudstack-management-cleanup-jars
 %attr(0755,root,root) %{_bindir}/cmk
 %{_datadir}/%{name}-management/cks/conf/*.yml
 %{_datadir}/%{name}-management/setup/*.sql

--- a/packaging/systemd/cloudstack-management-cleanup-jars
+++ b/packaging/systemd/cloudstack-management-cleanup-jars
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # Remove first-party CloudStack jars left behind by manual deployments. These
 # jars are visible through the management server wildcard classpath and can
 # shadow resources from the newly installed RPM.

--- a/packaging/systemd/cloudstack-management-cleanup-jars
+++ b/packaging/systemd/cloudstack-management-cleanup-jars
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Remove first-party CloudStack jars left behind by manual deployments. These
+# jars are visible through the management server wildcard classpath and can
+# shadow resources from the newly installed RPM.
+set -eu
+
+LIB_DIR=${1:-/usr/share/cloudstack-management/lib}
+QUARANTINE_ROOT=${CLOUDSTACK_JAR_QUARANTINE_ROOT:-/var/lib/cloudstack/management/legacy-lib}
+RPM_BIN=${RPM_BIN:-rpm}
+
+if [ ! -d "$LIB_DIR" ]; then
+    exit 0
+fi
+
+timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+quarantine_dir="$QUARANTINE_ROOT/$timestamp"
+moved=0
+
+is_first_party_jar() {
+    case "$(basename "$1")" in
+        cloud-*.jar|cloudstack-*.jar)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+for jar in "$LIB_DIR"/*.jar; do
+    [ -e "$jar" ] || continue
+    is_first_party_jar "$jar" || continue
+    if "$RPM_BIN" -qf "$jar" >/dev/null 2>&1; then
+        continue
+    fi
+
+    if [ "$moved" -eq 0 ]; then
+        install -d -m 0700 "$quarantine_dir"
+    fi
+    echo "Quarantining unmanaged CloudStack jar: $jar"
+    mv -- "$jar" "$quarantine_dir/"
+    moved=$((moved + 1))
+done
+
+if [ "$moved" -gt 0 ]; then
+    echo "Quarantined $moved unmanaged CloudStack jar(s) in $quarantine_dir"
+fi

--- a/release/README.md
+++ b/release/README.md
@@ -1,18 +1,18 @@
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements. See the NOTICE file
+or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
-regarding copyright ownership. The ASF licenses this file
+regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at
+with the License.  You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied. See the License for the
+KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,43 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# ABLESTACK Release Metadata
+
+The product version is stored in `product-version.properties`. Release
+workflows combine it with the selected product branch, UTC build date, release
+stage, and prerelease sequence.
+
+Examples:
+
+```text
+ablestack-europa + alpha + 1 + 20260810
+  -> v4.10.0-Europa-20260810-ALPHA1
+
+ablestack-europa + ga + no sequence + 20260810
+  -> v4.10.0-Europa-20260810
+```
+
+The workflow generates `release-metadata.json` once and passes the completed
+`displayVersion` to downstream builds. Alpha, beta, and RC builds require a
+positive sequence and are GitHub prereleases. GA builds reject a prerelease
+sequence and are published as regular releases.
+
+The login page already prefixes the configured build version with the product
+title. Therefore, UI packages receive a value such as
+`v4.10.0-Europa-20260810-ALPHA1`, without another `ABLESTACK` prefix.

--- a/release/product-version.properties
+++ b/release/product-version.properties
@@ -1,17 +1,17 @@
 # Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements. See the NOTICE file
+# or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
-# regarding copyright ownership. The ASF licenses this file
+# regarding copyright ownership.  The ASF licenses this file
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
-# with the License. You may obtain a copy of the License at
+# with the License.  You may obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied. See the License for the
+# KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
 

--- a/release/product-version.properties
+++ b/release/product-version.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+product.version=4.10.0

--- a/tools/build/release_metadata.py
+++ b/tools/build/release_metadata.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import argparse
+import datetime
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+
+
+PRODUCT_VERSION_PATTERN = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+BRANCH_METADATA = {
+    "ablestack-europa": ("Europa", "Mold.Europa"),
+    "ablestack-diplo": ("Diplo", "Mold.Diplo"),
+}
+PRERELEASE_STAGES = {"alpha", "beta", "rc"}
+
+
+def read_product_version(version_file):
+    properties = {}
+    for raw_line in Path(version_file).read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, separator, value = line.partition("=")
+        if not separator:
+            raise ValueError(f"Invalid product version property: {raw_line}")
+        properties[key.strip()] = value.strip()
+
+    product_version = properties.get("product.version", "")
+    if not PRODUCT_VERSION_PATTERN.fullmatch(product_version):
+        raise ValueError(
+            "product.version must use numeric major.minor.patch format"
+        )
+    return product_version
+
+
+def derive_release_metadata(
+        product_version, base_branch, stage, stage_number, build_date,
+        git_commit="", workflow_run_id=""):
+    if base_branch not in BRANCH_METADATA:
+        raise ValueError(f"Unsupported base branch: {base_branch}")
+    if stage not in PRERELEASE_STAGES | {"ga"}:
+        raise ValueError(f"Unsupported release stage: {stage}")
+
+    try:
+        datetime.datetime.strptime(build_date, "%Y%m%d")
+    except ValueError as error:
+        raise ValueError("build date must be a valid YYYYMMDD value") from error
+
+    normalized_number = None
+    if stage in PRERELEASE_STAGES:
+        try:
+            normalized_number = int(stage_number)
+        except (TypeError, ValueError) as error:
+            raise ValueError(f"{stage} requires a positive release number") from error
+        if normalized_number < 1 or str(normalized_number) != str(stage_number):
+            raise ValueError(f"{stage} requires a positive release number")
+    elif stage_number not in (None, ""):
+        raise ValueError("ga must not define a prerelease number")
+
+    codename, brand = BRANCH_METADATA[base_branch]
+    display_version = f"v{product_version}-{codename}-{build_date}"
+    if normalized_number is not None:
+        display_version += f"-{stage.upper()}{normalized_number}"
+
+    return {
+        "product": "ABLESTACK",
+        "productVersion": product_version,
+        "codename": codename,
+        "brand": brand,
+        "buildDate": build_date,
+        "releaseStage": stage,
+        "prereleaseNumber": normalized_number,
+        "displayVersion": display_version,
+        "releaseName": f"ABLESTACK {display_version}",
+        "releaseTag": display_version,
+        "artifactVersion": display_version.removeprefix("v"),
+        "isPrerelease": stage != "ga",
+        "gitCommit": git_commit,
+        "workflowRunId": workflow_run_id,
+    }
+
+
+def write_json_atomic(output_path, metadata):
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    file_descriptor, temporary_path = tempfile.mkstemp(
+        prefix=f"{output.name}.", dir=output.parent
+    )
+    try:
+        with os.fdopen(file_descriptor, "w", encoding="utf-8") as stream:
+            json.dump(metadata, stream, indent=2, ensure_ascii=True)
+            stream.write("\n")
+        os.replace(temporary_path, output)
+    except Exception:
+        if os.path.exists(temporary_path):
+            os.unlink(temporary_path)
+        raise
+
+
+def write_github_outputs(output_path, metadata):
+    outputs = {
+        "brand": metadata["brand"],
+        "product_version": metadata["productVersion"],
+        "codename": metadata["codename"],
+        "build_date": metadata["buildDate"],
+        "release_stage": metadata["releaseStage"],
+        "prerelease_number": metadata["prereleaseNumber"] or "",
+        "display_version": metadata["displayVersion"],
+        "release_name": metadata["releaseName"],
+        "release_tag": metadata["releaseTag"],
+        "artifact_version": metadata["artifactVersion"],
+        "is_prerelease": str(metadata["isPrerelease"]).lower(),
+    }
+    with Path(output_path).open("a", encoding="utf-8") as stream:
+        for key, value in outputs.items():
+            stream.write(f"{key}={value}\n")
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Generate ABLESTACK release metadata")
+    parser.add_argument("--version-file", default="release/product-version.properties")
+    parser.add_argument("--base-branch", required=True)
+    parser.add_argument("--stage", required=True, choices=["alpha", "beta", "rc", "ga"])
+    parser.add_argument("--number", default="")
+    parser.add_argument("--build-date", default="")
+    parser.add_argument("--git-commit", default="")
+    parser.add_argument("--workflow-run-id", default="")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--github-output")
+    return parser.parse_args()
+
+
+def main():
+    arguments = parse_arguments()
+    build_date = arguments.build_date or datetime.datetime.now(
+        datetime.timezone.utc
+    ).strftime("%Y%m%d")
+    metadata = derive_release_metadata(
+        read_product_version(arguments.version_file),
+        arguments.base_branch,
+        arguments.stage,
+        arguments.number,
+        build_date,
+        arguments.git_commit,
+        arguments.workflow_run_id,
+    )
+    write_json_atomic(arguments.output, metadata)
+    if arguments.github_output:
+        write_github_outputs(arguments.github_output, metadata)
+    print(metadata["displayVersion"])
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/build/rocky97-rpm-build.sh
+++ b/tools/build/rocky97-rpm-build.sh
@@ -83,6 +83,7 @@ dnf --releasever=9.7 config-manager --set-enabled crb || true
     bash \
     bzip2 \
     ca-certificates \
+    cpio \
     findutils \
     gcc \
     genisoimage \
@@ -217,5 +218,67 @@ if [ "$package_status" -ne 0 ]; then
 fi
 
 cd "$ROOT_DIR"
+
+verify_management_schema_resources() {
+    local management_rpm
+    local extract_dir
+    local packaged_jar
+    local resource
+    local source_resource
+    local extracted_resource
+    local -a packaged_jars
+
+    management_rpm=$(find dist/rpmbuild/RPMS -type f -name 'cloudstack-management-*.rpm' | sort | tail -1)
+    if [ -z "$management_rpm" ]; then
+        echo "cloudstack-management RPM was not generated" >&2
+        return 1
+    fi
+
+    extract_dir=$(mktemp -d /tmp/cloudstack-management-rpm-XXXXXX)
+    (
+        cd "$extract_dir"
+        rpm2cpio "$ROOT_DIR/$management_rpm" | cpio -idm --quiet
+    )
+
+    mapfile -t packaged_jars < <(find "$extract_dir/usr/share/cloudstack-management/lib" -maxdepth 1 -type f -name 'cloudstack-*.jar' | sort)
+    if [ "${#packaged_jars[@]}" -ne 1 ]; then
+        echo "Expected exactly one packaged cloudstack application jar, found ${#packaged_jars[@]}" >&2
+        rm -rf "$extract_dir"
+        return 1
+    fi
+    packaged_jar=${packaged_jars[0]}
+
+    if find "$extract_dir/usr/share/cloudstack-management/lib" -maxdepth 1 -type f -name 'cloud-engine-schema-*.jar' | grep -q .; then
+        echo "Standalone cloud-engine-schema jar must not be packaged beside the application jar" >&2
+        rm -rf "$extract_dir"
+        return 1
+    fi
+
+    for resource in \
+        META-INF/db/schema-Europa-After.sql \
+        META-INF/db/views/cloud.shared_filesystem_view.sql; do
+        source_resource="$ROOT_DIR/engine/schema/src/main/resources/$resource"
+        extracted_resource=$(mktemp /tmp/cloudstack-schema-resource-XXXXXX)
+        if ! unzip -p "$packaged_jar" "$resource" >"$extracted_resource"; then
+            echo "Missing schema resource in packaged application jar: $resource" >&2
+            rm -f "$extracted_resource"
+            rm -rf "$extract_dir"
+            return 1
+        fi
+        if ! cmp -s "$source_resource" "$extracted_resource"; then
+            echo "Packaged schema resource differs from source: $resource" >&2
+            rm -f "$extracted_resource"
+            rm -rf "$extract_dir"
+            return 1
+        fi
+        rm -f "$extracted_resource"
+    done
+
+    rm -rf "$extract_dir"
+    echo "Verified management RPM schema resources: $management_rpm"
+}
+
+verify_management_schema_resources
+
 find dist/rpmbuild -type f \( -name '*.rpm' -o -name '*.src.rpm' \) | sort \
     > dist/rocky97-build/artifacts.txt

--- a/tools/build/rocky97-rpm-build.sh
+++ b/tools/build/rocky97-rpm-build.sh
@@ -32,6 +32,7 @@ TIMESTAMP_VALUE=${TIMESTAMP_VALUE:-}
 BUILD_SRPM=${BUILD_SRPM:-false}
 USE_TIMESTAMP=${USE_TIMESTAMP:-false}
 LOCAL_FAST=${LOCAL_FAST:-false}
+ABLESTACK_UI_BUILD_VERSION=${ABLESTACK_UI_BUILD_VERSION:-}
 
 if ! command -v dnf >/dev/null 2>&1; then
     echo "This helper must run inside a Rocky/RHEL-compatible environment with dnf."
@@ -57,6 +58,7 @@ echo "TIMESTAMP_VALUE=${TIMESTAMP_VALUE:-<generated>}"
 echo "BUILD_SRPM=$BUILD_SRPM"
 echo "USE_TIMESTAMP=$USE_TIMESTAMP"
 echo "LOCAL_FAST=$LOCAL_FAST"
+echo "ABLESTACK_UI_BUILD_VERSION=${ABLESTACK_UI_BUILD_VERSION:-<source-config>}"
 
 configure_rocky_vault_repositories() {
     local repo
@@ -157,6 +159,7 @@ mkdir -p "$ROOT_DIR/dist/rocky97-build"
     echo "build_srpm=$BUILD_SRPM"
     echo "use_timestamp=$USE_TIMESTAMP"
     echo "local_fast=$LOCAL_FAST"
+    echo "ui_build_version=${ABLESTACK_UI_BUILD_VERSION:-<source-config>}"
 } >"$ROOT_DIR/dist/rocky97-build/environment.txt"
 
 build_args=(
@@ -279,6 +282,41 @@ verify_management_schema_resources() {
 }
 
 verify_management_schema_resources
+
+verify_ui_build_version() {
+    local ui_rpm
+    local extract_dir
+    local packaged_version
+
+    if [ -z "$ABLESTACK_UI_BUILD_VERSION" ]; then
+        echo "Skipping UI build version verification because no release version was supplied"
+        return
+    fi
+
+    ui_rpm=$(find dist/rpmbuild/RPMS -type f -name 'cloudstack-ui-*.rpm' | sort | tail -1)
+    if [ -z "$ui_rpm" ]; then
+        echo "cloudstack-ui RPM was not generated" >&2
+        return 1
+    fi
+
+    extract_dir=$(mktemp -d /tmp/cloudstack-ui-rpm-XXXXXX)
+    (
+        cd "$extract_dir"
+        rpm2cpio "$ROOT_DIR/$ui_rpm" | cpio -idm --quiet
+    )
+    packaged_version=$(jq -r '.buildVersion // empty' \
+        "$extract_dir/etc/cloudstack/ui/config.json")
+    rm -rf "$extract_dir"
+
+    if [ "$packaged_version" != "$ABLESTACK_UI_BUILD_VERSION" ]; then
+        echo "Packaged UI buildVersion mismatch: expected $ABLESTACK_UI_BUILD_VERSION, got $packaged_version" >&2
+        return 1
+    fi
+
+    echo "Verified UI buildVersion in $ui_rpm: $packaged_version"
+}
+
+verify_ui_build_version
 
 find dist/rpmbuild -type f \( -name '*.rpm' -o -name '*.src.rpm' \) | sort \
     > dist/rocky97-build/artifacts.txt

--- a/tools/build/tests/test_release_metadata.py
+++ b/tools/build/tests/test_release_metadata.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "release_metadata.py"
+SPEC = importlib.util.spec_from_file_location("release_metadata", MODULE_PATH)
+RELEASE_METADATA = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(RELEASE_METADATA)
+
+
+class ReleaseMetadataTest(unittest.TestCase):
+    def test_alpha_europa_display_version(self):
+        metadata = RELEASE_METADATA.derive_release_metadata(
+            "4.10.0", "ablestack-europa", "alpha", "1", "20260810"
+        )
+
+        self.assertEqual(
+            "v4.10.0-Europa-20260810-ALPHA1", metadata["displayVersion"]
+        )
+        self.assertEqual(
+            "ABLESTACK v4.10.0-Europa-20260810-ALPHA1",
+            metadata["releaseName"],
+        )
+        self.assertTrue(metadata["isPrerelease"])
+
+    def test_ga_diplo_omits_stage_suffix(self):
+        metadata = RELEASE_METADATA.derive_release_metadata(
+            "4.10.0", "ablestack-diplo", "ga", "", "20260810"
+        )
+
+        self.assertEqual("v4.10.0-Diplo-20260810", metadata["displayVersion"])
+        self.assertFalse(metadata["isPrerelease"])
+
+    def test_prerelease_requires_positive_number(self):
+        with self.assertRaisesRegex(ValueError, "positive release number"):
+            RELEASE_METADATA.derive_release_metadata(
+                "4.10.0", "ablestack-europa", "rc", "", "20260810"
+            )
+
+    def test_ga_rejects_prerelease_number(self):
+        with self.assertRaisesRegex(ValueError, "must not define"):
+            RELEASE_METADATA.derive_release_metadata(
+                "4.10.0", "ablestack-europa", "ga", "1", "20260810"
+            )
+
+    def test_invalid_calendar_date_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "valid YYYYMMDD"):
+            RELEASE_METADATA.derive_release_metadata(
+                "4.10.0", "ablestack-europa", "beta", "1", "20260230"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/build.js
+++ b/ui/build.js
@@ -20,9 +20,9 @@
 const fs = require('fs')
 const path = require('path')
 
-const CONFIG_PATH = path.resolve(__dirname, './public/config.json')
-const VERSION_PATH = '/mnt/version.txt'
+const CONFIG_PATH = path.resolve(process.argv[2] || path.join(__dirname, 'dist/config.json'))
 const TMP_PATH = CONFIG_PATH + '.tmp'
+const RELEASE_VERSION_PATTERN = /^v\d+\.\d+\.\d+-(Europa|Diplo)-\d{8}(?:-(ALPHA|BETA|RC)\d+)?$/
 
 function readJSON (file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'))
@@ -35,21 +35,20 @@ function writeJSONAtomic (file, obj) {
 }
 
 function getBuildVersion () {
-  try {
-    // 개행/공백 제거해서 그대로 사용
-    const v = fs.readFileSync(VERSION_PATH, 'utf8').trim()
-    if (v) return v
-  } catch (_) {}
-  // fallback: v4.5.0-YYYYMMDD
-  const base = 'v4.5.0'
-  const d = new Date()
-  const yyyy = d.getFullYear()
-  const mm = String(d.getMonth() + 1).padStart(2, '0')
-  const dd = String(d.getDate()).padStart(2, '0')
-  return `${base}-${yyyy}${mm}${dd}`
+  const buildVersion = (process.env.ABLESTACK_UI_BUILD_VERSION || '').trim()
+  if (!buildVersion) return null
+  if (!RELEASE_VERSION_PATTERN.test(buildVersion)) {
+    throw new Error(`Invalid ABLESTACK_UI_BUILD_VERSION: ${buildVersion}`)
+  }
+  return buildVersion
 }
 
 const data = readJSON(CONFIG_PATH)
-data.buildVersion = getBuildVersion()
-writeJSONAtomic(CONFIG_PATH, data)
-console.log('[OK] buildVersion:', data.buildVersion)
+const buildVersion = getBuildVersion()
+if (buildVersion) {
+  data.buildVersion = buildVersion
+  writeJSONAtomic(CONFIG_PATH, data)
+  console.log('[OK] buildVersion:', data.buildVersion)
+} else {
+  console.log('[SKIP] ABLESTACK_UI_BUILD_VERSION is not set; keeping buildVersion:', data.buildVersion)
+}

--- a/ui/postbuild.sh
+++ b/ui/postbuild.sh
@@ -34,3 +34,11 @@ console.log(JSON.stringify(data, null, 2));
 EOF
 
 mv ${tmpFile} ${configFile}
+
+distConfigFile="$DIR/dist/config.json"
+if [ ! -f "$distConfigFile" ]; then
+    echo "Missing built UI configuration: $distConfigFile" >&2
+    exit 1
+fi
+
+node "$DIR/build.js" "$distConfigFile"


### PR DESCRIPTION
## 변경 개요

Europa 릴리스 설치 정합성과 제품 버전 표기 체계를 함께 개선합니다.

- RPM 설치 시 수동 배포에서 남은 구버전 관리 JAR을 안전하게 격리합니다.
- 단일 릴리스 메타데이터로 UI, RPM, KVM SystemVM Template의 제품 버전을 생성합니다.
- 이번 검증 버전은 `ABLESTACK v4.10.0-Europa-20260810-ALPHA1`입니다.

## RPM 설치 정합성

- `cloudstack-management-cleanup-jars`를 추가해 RPM이 소유하지 않는 1차 CloudStack JAR을 격리합니다.
- 관리 패키지 `%posttrans`에서 정리 작업을 Mold 재시작보다 먼저 수행합니다.
- 정리 실패 시 혼합 클래스패스로 서비스를 시작하지 않도록 중단합니다.
- Rocky 9.7 RPM 빌드에서 다음을 검증합니다.
  - 관리 RPM의 애플리케이션 fat JAR이 정확히 하나인지 확인
  - 독립 `cloud-engine-schema` JAR이 포함되지 않았는지 확인
  - fat JAR 내부 Europa 스키마와 SharedFS 뷰 SQL이 소스와 일치하는지 확인

## 릴리스 버전 메타데이터

- `release/product-version.properties`를 제품 버전의 단일 기준으로 사용합니다.
- 릴리스 코드명, UTC 빌드 날짜, 단계와 순번을 조합해 표시 버전을 생성합니다.
- 지원 단계는 `ALPHA`, `BETA`, `RC`, `GA`이며 GA 이외 단계는 양의 순번을 요구합니다.
- 브랜치 개발 릴리스와 정식 릴리스가 동일한 메타데이터 생성기를 사용합니다.
- 생성된 표시 버전을 다음 산출물에 전달합니다.
  - UI `config.json`의 `buildVersion`
  - Rocky 9.7 RPM 빌드 메타데이터
  - KVM SystemVM Template manifest

## 검증

- `git diff --check` 통과
- 릴리스 메타데이터 단위 테스트 5건 통과
- 신규·변경 Shell/Python 파일 구문 검사 통과
- origin 테스트 릴리스 전체 성공
  - noredist Rocky 9.7 RPM
  - UI RPM 내부 표시 버전
  - KVM SystemVM Template 및 manifest
  - 개발용 draft Release
  - https://github.com/dhslove/ablestack-cloud/actions/runs/31386294769
- 22.10 테스트 서버 RPM 설치 검증
  - `mold.service` active/enabled
  - `/client/` HTTP 200
  - SharedFS 스키마와 뷰 정상
  - 구버전 JAR로 인한 `Unknown column` 오류 재발 없음

## CI 참고

- PR 변경 파일에 직접 귀속된 관리 JAR 정리 스크립트의 Apache 라이선스 헤더를 보완했습니다.
- upstream 기준 브랜치에도 존재하는 기존 RAT 및 전역 pre-commit 항목과 변경 범위 밖 서버 단위 테스트 실패는 PR 변경과 분리해 확인합니다.
