### PR TITLE
[Mold Diplo] 가상머신 복제 시 발생하는 스토리지 풀 간 템플릿 ID 불일치 버그 수정

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -9997,6 +9997,12 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                     cmd.setEntityUuid(cloneVM.getUuid());
                     cmd.setEntityId(cloneVM.getId());
 
+                    VolumeVO rootVolToUpdate = _volsDao.findById(rootVolume.getId());
+                    if (rootVolToUpdate != null) {
+                        rootVolToUpdate.setTemplateId(cloneVM.getTemplateId());
+                        _volsDao.update(rootVolume.getId(), rootVolToUpdate);
+                    }
+
                     VMInstanceVO vmInstance = _vmInstanceDao.findById(cloneVM.getId());
                     vmInstance.setGuestOSId(cmd.getTargetVM().getGuestOSId());
                     _vmInstanceDao.update(cloneVM.getId(), vmInstance);
@@ -10155,6 +10161,12 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 cmd.setEntityId(cloneVM.getId());
                 markFastCloneVmStatus(cloneVM.getId(), FAST_CLONE_FLATTEN_PENDING, operationId);
                 userVmDetailsDao.addDetail(cloneVM.getId(), FAST_CLONE_SOURCE_VM_ID, String.valueOf(curVm.getId()), false);
+
+                VolumeVO rootVolToUpdate = _volsDao.findById(rootVolume.getId());
+                if (rootVolToUpdate != null) {
+                    rootVolToUpdate.setTemplateId(cloneVM.getTemplateId());
+                    _volsDao.update(rootVolume.getId(), rootVolToUpdate);
+                }
 
                 VMInstanceVO vmInstance = _vmInstanceDao.findById(cloneVM.getId());
                 vmInstance.setGuestOSId(cmd.getTargetVM().getGuestOSId());


### PR DESCRIPTION
## 설명
이 PR은 서로 다른 스토리지 풀 환경에서 가상머신을 복제할 때 발생하는 치명적인 배포 실패 버그를 해결합니다.
### 원인
가상머신 복제 과정에서 시스템은 임시 더미 템플릿을 생성하여 새 가상머신(`vm_instance` 테이블)에 할당합니다. 하지만 스토리지에 복사된 ROOT 볼륨(`volumes` 테이블)은 원본 가상머신이 사용하던 예전 `template_id`를 그대로 상속받습니다. 
이 상태에서 복제된 가상머신을 시작(Start)하려고 하면, `DeploymentPlanningManager`가 VM과 볼륨 간의 템플릿 ID가 다르다는 것(`template ids don't match`)을 감지하고 스토리지 풀 할당을 거부하여 결국 부팅에 실패하게 됩니다.
### 수정 사항
- **`UserVmManagerImpl.java`**: 가상머신 생성이 완료된 직후, 복제된 ROOT 볼륨의 `template_id`를 방금 생성된 새 가상머신의 더미 `template_id`와 똑같이 일치시키도록 덮어쓰는 방어 로직을 추가했습니다.
- 일반 복제 로직(`cloneVirtualMachine`)과 고속 복제 로직(`cloneVirtualMachineUsingSharedMountPointFastClone`) 두 군데 모두 동일한 패치를 적용하여 빈틈을 없앴습니다.


<!--- 변경 사항에 대해 자세하게 설명하십시오. 그리고 변경사항을 어떻게 실행하는지도 설명합니다. -->

<!-- 새로운 기능에 대한 PR인 경우, 타당성 조사(FS) 및 디자인 컨셉(DS) 등에 대한 위키 또는 문서 등을 링크합니다. -->
<!-- 버그 수정에 대한 PR인 경우, 재현을 위한 과정과 기대 실행 및 실제 실행 결과에 대한 내용을 설명합니다. -->

<!-- "Fixes #<id>"를 사용하면 해당 이슈 및 PR이 관련 이슈/PR로 등록되어 PR이 Merge 될 때 자동으로 종료됩니다. -->
<!-- 여려 개의 이슈 또는 PR을 지정하고자 하는 경우, 여러 개의 "Fixes #<id>"를 작성합니다. -->
<!-- Fixes # -->


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [x] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [ ] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [ ] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [ ] 주요 기능/개선
- [ ] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [x] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [ ] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->


