### PR TITLE
가상머신 생성 화면의 팝업 메뉴 투명화 버그 및 플레이스홀더 색상 가시성 개선

### DIFF
--- a/ui/src/style/theme/tokens.less
+++ b/ui/src/style/theme/tokens.less
@@ -31,7 +31,7 @@
   --ui-text-primary: #1f2937;
   --ui-text-secondary: #4b5563;
   --ui-text-muted: #667085;
-  --ui-text-placeholder: #667085;
+  --ui-text-placeholder: #bfbfbf;
   --ui-text-disabled: #7b8491;
   --ui-focus: #1677ff;
   --ui-link: #0969da;
@@ -73,7 +73,7 @@ body.dark-mode {
   --ui-text-primary: #f0f3f6;
   --ui-text-secondary: #c5ccd4;
   --ui-text-muted: #9aa4af;
-  --ui-text-placeholder: #a8b1bb;
+  --ui-text-placeholder: #7f8994;
   --ui-text-disabled: #7f8994;
   --ui-focus: #4096ff;
   --ui-link: #69b1ff;

--- a/ui/src/views/compute/DeployVM.vue
+++ b/ui/src/views/compute/DeployVM.vue
@@ -900,8 +900,8 @@
                 {{ this.form.startvm ? $t('label.launch.vm') : $t('label.create.vm') }}
                 <template #icon><down-outlined /></template>
                 <template #overlay>
-                  <a-menu type="primary" @click="handleSubmitAndStay" theme="dark" class="btn-stay-on-page">
-                    <a-menu-item type="primary" key="1">
+                  <a-menu @click="handleSubmitAndStay">
+                    <a-menu-item key="1">
                       <rocket-outlined />
                       {{ this.form.startvm ? $t('label.launch.vm.and.stay') : $t('label.create.vm.and.stay') }}
                     </a-menu-item>
@@ -3190,13 +3190,5 @@ export default {
 
   .form-item-hidden {
     display: none;
-  }
-
-  .btn-stay-on-page {
-    &.ant-dropdown-menu-dark {
-      .ant-dropdown-menu-item:hover {
-        background: transparent !important;
-      }
-    }
   }
 </style>

--- a/ui/src/views/compute/DeployVnfAppliance.vue
+++ b/ui/src/views/compute/DeployVnfAppliance.vue
@@ -833,8 +833,8 @@
                 {{ $t('label.launch.vnf.appliance') }}
                 <template #icon><down-outlined /></template>
                 <template #overlay>
-                  <a-menu type="primary" @click="handleSubmitAndStay" theme="dark" class="btn-stay-on-page">
-                    <a-menu-item type="primary" key="1">
+                  <a-menu @click="handleSubmitAndStay">
+                    <a-menu-item key="1">
                       <rocket-outlined />
                       {{ $t('label.launch.vnf.appliance.and.stay') }}
                     </a-menu-item>
@@ -2946,13 +2946,5 @@ export default {
 
   .form-item-hidden {
     display: none;
-  }
-
-  .btn-stay-on-page {
-    &.ant-dropdown-menu-dark {
-      .ant-dropdown-menu-item:hover {
-        background: transparent !important;
-      }
-    }
   }
 </style>


### PR DESCRIPTION
##  설명
이 PR은 프론트엔드(UI)에서 사용자의 편의성을 심각하게 저해하던 두 가지 렌더링 및 스타일링 이슈를 해결합니다.
### 주요 수정 사항 
**1. "현재 페이지 유지" 팝업 메뉴 투명화 버그 수정**
- **대상:** `DeployVM.vue`, `DeployVnfAppliance.vue`
- **원인:** 과거 Ant Design Vue 구버전 시절 버튼 색상을 맞추기 위해 강제로 주입했던 `theme="dark"` 속성과 커스텀 투명화 CSS(`.btn-stay-on-page`)가 최신 프레임워크에서 충돌을 일으켜, 메뉴 텍스트와 배경이 모두 투명해지는 "유령 상자" 현상 발생.
- **해결:** 오작동을 유발하는 해당 레거시 속성과 CSS를 완전히 제거하여 프레임워크의 기본 테마 동작(Light/Dark 모드 자동 적응)을 따르도록 정상화했습니다.

**2. 텍스트 입력창 플레이스홀더(Placeholder) 색상 변경**
- **대상:** `style/theme/tokens.less`
- **원인:** 최근 Light/Dark 테마 통합 패치 과정에서 일반 모드의 플레이스홀더 색상이 너무 진한 회색(`#667085`)으로 설정되어, 사용자가 이미 값을 입력한 것으로 착각하게 만드는 UX 저하 유발.
- **해결:** 전역 플레이스홀더 색상을 UI 표준에 맞게 실제 텍스트와 뚜렷이 구분되는 연한 색상(Light: `#bfbfbf`, Dark: `#7f8994`)으로 교체했습니다.
<!--- 변경 사항에 대해 자세하게 설명하십시오. 그리고 변경사항을 어떻게 실행하는지도 설명합니다. -->

<!-- 새로운 기능에 대한 PR인 경우, 타당성 조사(FS) 및 디자인 컨셉(DS) 등에 대한 위키 또는 문서 등을 링크합니다. -->
<!-- 버그 수정에 대한 PR인 경우, 재현을 위한 과정과 기대 실행 및 실제 실행 결과에 대한 내용을 설명합니다. -->

<!-- "Fixes #<id>"를 사용하면 해당 이슈 및 PR이 관련 이슈/PR로 등록되어 PR이 Merge 될 때 자동으로 종료됩니다. -->
<!-- 여려 개의 이슈 또는 PR을 지정하고자 하는 경우, 여러 개의 "Fixes #<id>"를 작성합니다. -->
<!-- Fixes # -->


### 변경 구분

- [ ] 잠재적 기능/오류 개선 (기존의 기능에 잠재되어 있는 오류 또는 다른 기능에 영향을 미칠 기능의 개선)
- [ ] 새로운 기능 (다른 기능에 영향을 미치지 않는 새 기능)
- [x] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)
- [ ] 기능 개선 (기존 기능에 대한 개선으로 다른 기능에 영향을 미치지 않음)
- [x] 코드 청소 (코드 재구성 및 청소, 테스트 케이스 추가 등)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [ ] 주요 기능/개선
- [x] 소규모 기능/개선

#### 버그 심각도

- [ ] 매우 심각 (제품 출시/운영을 불가능하게 함)
- [ ] 위험 (사용자에게 자원의 손실을 가져오게 함)
- [x] 중요 (사용자에게 기능 사용의 불편을 가져오게 함)
- [ ] 보통 (사용자가 문제를 인지할 수 있을 정도임)
- [ ] 미미 (사용자가 인지하지 못할 정도임)


### 스크린샷


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->


